### PR TITLE
Feat/calculator support

### DIFF
--- a/KuroganeHammer.Data.Core/Calculations/Calculator.cs
+++ b/KuroganeHammer.Data.Core/Calculations/Calculator.cs
@@ -3,12 +3,38 @@
     public class Calculator
     {
         public double TrainingModeKnockback(double victimPercent, int baseDamage, double targetWeight,
-            double knockbackGrowth, int baseKnockbackSetKnockback, double modifier)
+            double knockbackGrowth, int baseKnockbackSetKnockback, double stanceModifier)
         {
             double result = 0;
 
             result = (((victimPercent + baseDamage) / 10 + (victimPercent + baseDamage) * baseDamage / 20) * (200 / (targetWeight + 100)) * 1.4 + 18) * (knockbackGrowth / 100)
-            + baseKnockbackSetKnockback * modifier;
+            + baseKnockbackSetKnockback * stanceModifier;
+
+            return result;
+        }
+
+        public double VersusModeKnockback(double victimPercent, int baseDamage, double staleMoveMultiplier,
+            double targetWeight, double knockbackGrowth, int baseKnockbackSetKnockback, double stanceModifier)
+        {
+            var result = ((((victimPercent + baseDamage * staleMoveMultiplier) / 10 +
+                               (victimPercent + baseDamage * staleMoveMultiplier) * baseDamage *
+                               (1 - (1 - staleMoveMultiplier) * 0.3) / 20)
+                              * 1.4 * (200 / (targetWeight + 100)) + 18) * (knockbackGrowth / 100) + baseKnockbackSetKnockback) *
+                            stanceModifier * Rage(victimPercent);
+
+            return result;
+        }
+
+        public double Rage(double percent)
+        {
+
+            double result = 0;
+
+            if (percent > 35 &&
+                percent < 150)
+            {
+                result = 1 + (percent - 35)*(1.15 - 1)/(150 - 35);
+            }
 
             return result;
         }

--- a/KuroganeHammer.Data.Core/Calculations/Calculator.cs
+++ b/KuroganeHammer.Data.Core/Calculations/Calculator.cs
@@ -20,20 +20,19 @@ namespace KuroganeHammer.Data.Core.Calculations
                                (data.VictimPercent + data.BaseDamage * data.StaleMoveMultiplier) * data.BaseDamage *
                                (1 - (1 - data.StaleMoveMultiplier) * 0.3) / 20)
                               * 1.4 * (200 / (data.TargetWeight + 100)) + 18) * (data.KnockbackGrowth / 100) + data.BaseKnockbackSetKnockback) *
-                            data.StanceModifier * Rage(data.VictimPercent);
+                            data.StanceModifier * Rage(new RageProblemData {AttackerPercent = data.AttackerPercent});
 
             return result;
         }
 
-        public double Rage(double percent)
+        public double Rage(RageProblemData data)
         {
-
             double result = 0;
 
-            if (percent > 35 &&
-                percent < 150)
+            if (data.AttackerPercent > 35 &&
+                data.AttackerPercent < 150)
             {
-                result = 1 + (percent - 35) * (1.15 - 1) / (150 - 35);
+                result = 1 + (data.AttackerPercent - 35) * (1.15 - 1) / (150 - 35);
             }
 
             return result;
@@ -122,7 +121,7 @@ namespace KuroganeHammer.Data.Core.Calculations
 
             switch (data.ShieldAdvantageModifier)
             {
-                case ShieldAdvantageModifier.Projectile_NotHitlag:
+                case ShieldAdvantageModifier.ProjectileNotHitlag:
                     {
                         var hitlag = Hitlag(data.HitlagData);
                         shieldAdvantage = shieldAdvantage + hitlag;//(int)(Convert.ToDouble(shieldAdvantage) + Math.Round(hitlag));

--- a/KuroganeHammer.Data.Core/Calculations/Calculator.cs
+++ b/KuroganeHammer.Data.Core/Calculations/Calculator.cs
@@ -2,32 +2,48 @@
 
 namespace KuroganeHammer.Data.Core.Calculations
 {
+    /// <summary>
+    /// Handles all calculations dealing with actionable move data.
+    /// </summary>
     public class Calculator
     {
+        /// <summary>
+        /// Returns the knockback as if in training mode.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
         public double TrainingModeKnockback(TrainingModeKnockbackProblemData data)
         {
-            double result = 0;
-
-            result = (((data.VictimPercent + data.BaseDamage) / 10 + (data.VictimPercent + data.BaseDamage) * data.BaseDamage / 20) * (200 / (data.TargetWeight + 100)) * 1.4 + 18) * (data.KnockbackGrowth / 100)
-            + data.BaseKnockbackSetKnockback * data.StanceModifier;
+            var result = (((data.VictimPercent + data.BaseDamage) / 10 + (data.VictimPercent + data.BaseDamage) * data.BaseDamage / 20) * (200 / (data.TargetWeight + 100)) * 1.4 + 18) * (data.KnockbackGrowth / 100)
+                            + data.BaseKnockbackSetKnockback * data.StanceModifier;
 
             return result;
         }
 
+        /// <summary>
+        /// Returns the knockback as if in versus mode.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
         public double VersusModeKnockback(VersusModeKnockbackProblemData data)
         {
             var result = ((((data.VictimPercent + data.BaseDamage * data.StaleMoveMultiplier) / 10 +
                                (data.VictimPercent + data.BaseDamage * data.StaleMoveMultiplier) * data.BaseDamage *
                                (1 - (1 - data.StaleMoveMultiplier) * 0.3) / 20)
                               * 1.4 * (200 / (data.TargetWeight + 100)) + 18) * (data.KnockbackGrowth / 100) + data.BaseKnockbackSetKnockback) *
-                            data.StanceModifier * Rage(new RageProblemData {AttackerPercent = data.AttackerPercent});
+                            data.StanceModifier * Rage(new RageProblemData { AttackerPercent = data.AttackerPercent });
 
             return result;
         }
 
+        /// <summary>
+        /// Returns the calculated rage.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
         public double Rage(RageProblemData data)
         {
-            double result = 0;
+            double result = 1;
 
             if (data.AttackerPercent > 35 &&
                 data.AttackerPercent < 150)
@@ -38,31 +54,61 @@ namespace KuroganeHammer.Data.Core.Calculations
             return result;
         }
 
+        /// <summary>
+        /// Returns the calculated Hitstun.
+        /// </summary>
+        /// <param name="knockbackGrowth"></param>
+        /// <returns></returns>
         public int Hitstun(double knockbackGrowth)
         {
             return (int)Math.Floor(knockbackGrowth * 0.4) - 1;
         }
 
+        /// <summary>
+        /// Returns the calculated Normal Shield stun.
+        /// </summary>
+        /// <param name="damage"></param>
+        /// <returns></returns>
         public int ShieldStunNormal(double damage)
         {
             return (int)Math.Floor(damage / 1.72 + 3.0 - 1.0);
         }
 
+        /// <summary>
+        /// Returns the calculated Power shielded Shield stun.
+        /// </summary>
+        /// <param name="damage"></param>
+        /// <returns></returns>
         public int ShieldStunPowerShield(double damage)
         {
             return (int)Math.Floor(damage / 2.61 + 3 - 1);
         }
 
+        /// <summary>
+        /// Returns the calculated Projectile Shield stun.
+        /// </summary>
+        /// <param name="damage"></param>
+        /// <returns></returns>
         public int ShieldStunProjectile(double damage)
         {
             return (int)Math.Floor(damage / 3.5 + 3 - 1);
         }
 
+        /// <summary>
+        /// Returns the calculated Power shielded projectile Shield stun.
+        /// </summary>
+        /// <param name="damage"></param>
+        /// <returns></returns>
         public int ShieldStunPowerShieldProjectile(double damage)
         {
             return (int)Math.Floor(damage / 5.22 + 3 - 1);
         }
 
+        /// <summary>
+        /// Returns the calculated Hitlag.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
         public int Hitlag(HitlagProblemData data)
         {
             var retVal = (int)Math.Floor((data.Damage / 2.6 + 5) *
@@ -78,30 +124,40 @@ namespace KuroganeHammer.Data.Core.Calculations
             return retVal;
         }
 
-        public double HitlagRaw(HitlagProblemData data)
-        {
-            var retVal = (data.Damage / 2.6 + 5) *
-               data.ElectricModifier.GetModifierValue() *
-               data.HitlagMultiplier *
-               data.CrouchingModifier.GetModifierValue() - 1;
+        ///// <summary>
+        ///// Returns the calculated Hitlag.
+        ///// </summary>
+        ///// <param name="data"></param>
+        ///// <returns></returns>
+        //public double HitlagRaw(HitlagProblemData data)
+        //{
+        //    var retVal = (data.Damage / 2.6 + 5) *
+        //       data.ElectricModifier.GetModifierValue() *
+        //       data.HitlagMultiplier *
+        //       data.CrouchingModifier.GetModifierValue() - 1;
 
-            if (retVal > 30)
-            {
-                retVal = 30;
-            }
+        //    if (retVal > 30)
+        //    {
+        //        retVal = 30;
+        //    }
 
-            return retVal;
-        }
+        //    return retVal;
+        //}
 
+        /// <summary>
+        /// Returns the calculated LedgeIntangibility.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
         public int LedgeIntangibility(LedgeIntangiblityProblemData data)
         {
             if (data.AirborneFrames > 300)
-            { throw new Exception($"{nameof(data.AirborneFrames)} cannot be higher than 300.");}
+            { throw new Exception($"{nameof(data.AirborneFrames)} cannot be higher than 300."); }
 
             if (data.CharacterPercentage > 120)
-            { throw new Exception($"{nameof(data.CharacterPercentage)} cannot be higher than 120.");}
+            { throw new Exception($"{nameof(data.CharacterPercentage)} cannot be higher than 120."); }
 
-            var result = (int)Math.Floor(data.AirborneFrames*0.2 + 64 - data.CharacterPercentage*44/120.0);
+            var result = (int)Math.Floor(data.AirborneFrames * 0.2 + 64 - data.CharacterPercentage * 44 / 120.0);
 
             if (result < 24)
             { result = 24; }
@@ -112,6 +168,11 @@ namespace KuroganeHammer.Data.Core.Calculations
             return result;
         }
 
+        /// <summary>
+        /// Returns the calculated shield advantage.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
         public int ShieldAdvantage(ShieldAdvantageProblemData data)
         {
             var shieldAdvantage = data.HitFrame - (data.FirstActionableFrame - 1) + data.ShieldStun;
@@ -148,16 +209,31 @@ namespace KuroganeHammer.Data.Core.Calculations
             //return (int) Math.Floor(data.Damage*15/8 + 7.5);
         }
 
+        /// <summary>
+        /// Returns the calculated grab duration frames.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
         public int GrabDuration(GrabDurationProblemData data)
         {
-            return (int) (Math.Floor(90 + data.TargetPercent*1.7) - data.Input.GetModifierValue());
+            return (int)(Math.Floor(90 + data.TargetPercent * 1.7) - data.Input.GetModifierValue());
         }
 
+        /// <summary>
+        /// Returns the calculated Pikmin grab durations frames.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
         public int PikminGrabDuration(PikminGrabDurationProblemData data)
         {
             return (int)(Math.Floor(360.0 - data.TargetPercent) - data.Input.GetModifierValue());
         }
 
+        /// <summary>
+        /// Returns the calculated Smash charge frames.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
         public int SmashCharge(SmashChargeProblemData data)
         {
             return (int)Math.Round(data.Damage * (data.HeldFrames / data.SmashChargeModifier.GetModifierValue()));

--- a/KuroganeHammer.Data.Core/Calculations/Calculator.cs
+++ b/KuroganeHammer.Data.Core/Calculations/Calculator.cs
@@ -1,26 +1,26 @@
-﻿namespace KuroganeHammer.Data.Core.Calculations
+﻿using System;
+
+namespace KuroganeHammer.Data.Core.Calculations
 {
     public class Calculator
     {
-        public double TrainingModeKnockback(double victimPercent, int baseDamage, double targetWeight,
-            double knockbackGrowth, int baseKnockbackSetKnockback, double stanceModifier)
+        public double TrainingModeKnockback(TrainingModeKnockbackProblemData data)
         {
             double result = 0;
 
-            result = (((victimPercent + baseDamage) / 10 + (victimPercent + baseDamage) * baseDamage / 20) * (200 / (targetWeight + 100)) * 1.4 + 18) * (knockbackGrowth / 100)
-            + baseKnockbackSetKnockback * stanceModifier;
+            result = (((data.VictimPercent + data.BaseDamage) / 10 + (data.VictimPercent + data.BaseDamage) * data.BaseDamage / 20) * (200 / (data.TargetWeight + 100)) * 1.4 + 18) * (data.KnockbackGrowth / 100)
+            + data.BaseKnockbackSetKnockback * data.StanceModifier;
 
             return result;
         }
 
-        public double VersusModeKnockback(double victimPercent, int baseDamage, double staleMoveMultiplier,
-            double targetWeight, double knockbackGrowth, int baseKnockbackSetKnockback, double stanceModifier)
+        public double VersusModeKnockback(VersusModeKnockbackProblemData data)
         {
-            var result = ((((victimPercent + baseDamage * staleMoveMultiplier) / 10 +
-                               (victimPercent + baseDamage * staleMoveMultiplier) * baseDamage *
-                               (1 - (1 - staleMoveMultiplier) * 0.3) / 20)
-                              * 1.4 * (200 / (targetWeight + 100)) + 18) * (knockbackGrowth / 100) + baseKnockbackSetKnockback) *
-                            stanceModifier * Rage(victimPercent);
+            var result = ((((data.VictimPercent + data.BaseDamage * data.StaleMoveMultiplier) / 10 +
+                               (data.VictimPercent + data.BaseDamage * data.StaleMoveMultiplier) * data.BaseDamage *
+                               (1 - (1 - data.StaleMoveMultiplier) * 0.3) / 20)
+                              * 1.4 * (200 / (data.TargetWeight + 100)) + 18) * (data.KnockbackGrowth / 100) + data.BaseKnockbackSetKnockback) *
+                            data.StanceModifier * Rage(data.VictimPercent);
 
             return result;
         }
@@ -37,6 +37,16 @@
             }
 
             return result;
+        }
+
+        public int Hitstun(double knockbackGrowth)
+        {
+            return (int)Math.Floor(knockbackGrowth*0.4) - 1;
+        }
+
+        public int ShieldStunNormal(double damage)
+        {
+            return (int)Math.Floor(damage / 1.72 + 3.0 - 1.0);
         }
     }
 }

--- a/KuroganeHammer.Data.Core/Calculations/Calculator.cs
+++ b/KuroganeHammer.Data.Core/Calculations/Calculator.cs
@@ -1,0 +1,16 @@
+﻿namespace KuroganeHammer.Data.Core.Calculations
+{
+    public class Calculator
+    {
+        public double TrainingModeKnockback(double victimPercent, int baseDamage, double targetWeight,
+            double knockbackGrowth, int baseKnockbackSetKnockback, double modifier)
+        {
+            double result = 0;
+
+            result = (((victimPercent + baseDamage) / 10 + (victimPercent + baseDamage) * baseDamage / 20) * (200 / (targetWeight + 100)) * 1.4 + 18) * (knockbackGrowth / 100)
+            + baseKnockbackSetKnockback * modifier;
+
+            return result;
+        }
+    }
+}

--- a/KuroganeHammer.Data.Core/Calculations/Calculator.cs
+++ b/KuroganeHammer.Data.Core/Calculations/Calculator.cs
@@ -33,7 +33,7 @@ namespace KuroganeHammer.Data.Core.Calculations
             if (percent > 35 &&
                 percent < 150)
             {
-                result = 1 + (percent - 35)*(1.15 - 1)/(150 - 35);
+                result = 1 + (percent - 35) * (1.15 - 1) / (150 - 35);
             }
 
             return result;
@@ -41,12 +41,132 @@ namespace KuroganeHammer.Data.Core.Calculations
 
         public int Hitstun(double knockbackGrowth)
         {
-            return (int)Math.Floor(knockbackGrowth*0.4) - 1;
+            return (int)Math.Floor(knockbackGrowth * 0.4) - 1;
         }
 
         public int ShieldStunNormal(double damage)
         {
             return (int)Math.Floor(damage / 1.72 + 3.0 - 1.0);
+        }
+
+        public int ShieldStunPowerShield(double damage)
+        {
+            return (int)Math.Floor(damage / 2.61 + 3 - 1);
+        }
+
+        public int ShieldStunProjectile(double damage)
+        {
+            return (int)Math.Floor(damage / 3.5 + 3 - 1);
+        }
+
+        public int ShieldStunPowerShieldProjectile(double damage)
+        {
+            return (int)Math.Floor(damage / 5.22 + 3 - 1);
+        }
+
+        public int Hitlag(HitlagProblemData data)
+        {
+            var retVal = (int)Math.Floor((data.Damage / 2.6 + 5) *
+                data.ElectricModifier.GetModifierValue() *
+                data.HitlagMultiplier *
+                data.CrouchingModifier.GetModifierValue()) - 1;
+
+            if (retVal > 30)
+            {
+                retVal = 30;
+            }
+
+            return retVal;
+        }
+
+        public double HitlagRaw(HitlagProblemData data)
+        {
+            var retVal = (data.Damage / 2.6 + 5) *
+               data.ElectricModifier.GetModifierValue() *
+               data.HitlagMultiplier *
+               data.CrouchingModifier.GetModifierValue() - 1;
+
+            if (retVal > 30)
+            {
+                retVal = 30;
+            }
+
+            return retVal;
+        }
+
+        public int LedgeIntangibility(LedgeIntangiblityProblemData data)
+        {
+            if (data.AirborneFrames > 300)
+            { throw new Exception($"{nameof(data.AirborneFrames)} cannot be higher than 300.");}
+
+            if (data.CharacterPercentage > 120)
+            { throw new Exception($"{nameof(data.CharacterPercentage)} cannot be higher than 120.");}
+
+            var result = (int)Math.Floor(data.AirborneFrames*0.2 + 64 - data.CharacterPercentage*44/120.0);
+
+            if (result < 24)
+            { result = 24; }
+
+            if (result > 124)
+            { result = 124; }
+
+            return result;
+        }
+
+        public int ShieldAdvantage(ShieldAdvantageProblemData data)
+        {
+            var shieldAdvantage = data.HitFrame - (data.FirstActionableFrame - 1) + data.ShieldStun;
+
+            if (data.HitlagData == null)
+            { throw new Exception($"{nameof(data.HitlagData)} cannot be null."); }
+
+            switch (data.ShieldAdvantageModifier)
+            {
+                case ShieldAdvantageModifier.Projectile_NotHitlag:
+                    {
+                        var hitlag = Hitlag(data.HitlagData);
+                        shieldAdvantage = shieldAdvantage + hitlag;//(int)(Convert.ToDouble(shieldAdvantage) + Math.Round(hitlag));
+                        break;
+                    }
+                case ShieldAdvantageModifier.Regular:
+                    {
+                        //shieldAdvantage = shieldAdvantage - hitlag;
+                        break;
+                    }
+                default:
+                    {
+                        break;
+                    }
+            }
+
+            return shieldAdvantage;
+        }
+
+        public int ReboundDuration(ReboundDurationProblemData data)
+        {
+            throw new NotImplementedException(
+                "Waiting on response from SpaceJam on this.  Not sure if the KH formula is good.");
+            //return (int) Math.Floor(data.Damage*15/8 + 7.5);
+        }
+
+        public int GrabDuration(GrabDurationProblemData data)
+        {
+            return (int) (Math.Floor(90 + data.TargetPercent*1.7) - data.Input.GetModifierValue());
+        }
+
+        public int PikminGrabDuration(PikminGrabDurationProblemData data)
+        {
+            return (int)(Math.Floor(360.0 - data.TargetPercent) - data.Input.GetModifierValue());
+        }
+
+        public int SmashCharge(SmashChargeProblemData data)
+        {
+            return (int)Math.Round(data.Damage * (data.HeldFrames / data.SmashChargeModifier.GetModifierValue()));
+        }
+
+        public double StaleMoveNegationMultiplier(StaleMoveNegationMultipler multiplier)
+        {
+            throw new NotImplementedException("Contact SpaceJam to explain this one.");
         }
     }
 }

--- a/KuroganeHammer.Data.Core/Calculations/Modifiers.cs
+++ b/KuroganeHammer.Data.Core/Calculations/Modifiers.cs
@@ -53,9 +53,12 @@ namespace KuroganeHammer.Data.Core.Calculations
         ElectricAttack
     }
 
-    public enum HitlagModifierType
+    public enum CrouchingModifier
     {
+        [ModifierValue(0.67)]
         Crouching,
+
+        [ModifierValue(1.0)]
         NotCrouching
     }
 
@@ -63,5 +66,62 @@ namespace KuroganeHammer.Data.Core.Calculations
     {
         Regular,
         Projectile_NotHitlag
+    }
+
+    public enum ControllerInput
+    {
+        [ModifierValue(8.0)]
+        LStick,
+
+        [ModifierValue(14.3)]
+        Button
+    }
+
+    public enum PikminGrabControllerInput
+    {
+        [ModifierValue(7.0)]
+        LStick,
+
+        [ModifierValue(12.5)]
+        Button
+    }
+
+    public enum SmashChargeModifier
+    {
+        [ModifierValue(150)]
+        Default,
+
+        [ModifierValue(86)]
+        MegamanFSmash
+    }
+
+    public enum StaleMoveNegationMultipler
+    {
+        [ModifierValue(8.000)]
+        S1,
+
+        [ModifierValue(7.594)]
+        S2,
+
+        [ModifierValue(6.782)]
+        S3,
+
+        [ModifierValue(6.028)]
+        S4,
+
+        [ModifierValue(5.274)]
+        S5,
+
+        [ModifierValue(4.462)]
+        S6,
+
+        [ModifierValue(3.766)]
+        S7,
+
+        [ModifierValue(2.954)]
+        S8,
+
+        [ModifierValue(2.200)]
+        S9
     }
 }

--- a/KuroganeHammer.Data.Core/Calculations/Modifiers.cs
+++ b/KuroganeHammer.Data.Core/Calculations/Modifiers.cs
@@ -4,11 +4,21 @@ using System.Reflection;
 
 namespace KuroganeHammer.Data.Core.Calculations
 {
+    /// <summary>
+    /// Used to contain the actual value being used in the Core enum modifiers.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Field)]
     public class ModifierValueAttribute : Attribute
     {
+        /// <summary>
+        /// The value of the modifier used in calculations.
+        /// </summary>
         public double Value { get; }
 
+        /// <summary>
+        /// Create a new <see cref="ModifierValueAttribute"/> using the passed in value.
+        /// </summary>
+        /// <param name="value"></param>
         public ModifierValueAttribute(double value)
         {
             Guard.VerifyObjectNotNull(value, nameof(value));
@@ -16,8 +26,16 @@ namespace KuroganeHammer.Data.Core.Calculations
         }
     }
 
+    /// <summary>
+    /// Small helper class to get the <see cref="ModifierValueAttribute"/> data from an <see cref="Enum"/>.
+    /// </summary>
     public static class ModifierHelper
     {
+        /// <summary>
+        /// Get the value of the <see cref="ModifierValueAttribute"/> if it exists.
+        /// </summary>
+        /// <param name="modifier"></param>
+        /// <returns></returns>
         public static double GetModifierValue(this Enum modifier)
         {
             var modifierName = modifier.ToString();
@@ -35,105 +53,225 @@ namespace KuroganeHammer.Data.Core.Calculations
     /// </summary>
     public enum HitboxOptions
     {
+        /// <summary>
+        /// First hitbox.
+        /// </summary>
         First,
+
+        /// <summary>
+        /// Second hitbox
+        /// </summary>
         Second,
+
+        /// <summary>
+        /// Third hitbox
+        /// </summary>
         Third,
+
+        /// <summary>
+        /// Fourth hitbox
+        /// </summary>
         Fourth,
+
+        /// <summary>
+        /// Fifth hitbox
+        /// </summary>
         Fifth
     }
 
+    /// <summary>
+    /// What the attack victim is doing when hit.
+    /// </summary>
     public enum Modifiers
     {
+        /// <summary>
+        /// Just standing = 1.0
+        /// </summary>
         [ModifierValue(1.0)]
         Standing,
 
+        /// <summary>
+        /// Charging a smash attack = 1.2
+        /// </summary>
         [ModifierValue(1.2)]
         ChargingSmash,
 
+        /// <summary>
+        /// Crouching = 0.85
+        /// </summary>
         [ModifierValue(0.85)]
         CrouchCancelling,
 
+        /// <summary>
+        /// Grounded Meteor = 0.8
+        /// </summary>
         [ModifierValue(0.8)]
         GroundedMeteor
     }
 
+    /// <summary>
+    /// Whether or not the attack is electric.  
+    /// Depending on whether or not more factors come out for this in the future it can be a bool instead.
+    /// </summary>
     public enum ElectricModifier
     {
+        /// <summary>
+        /// A normal, non-elemental attack = 1.0
+        /// </summary>
         [ModifierValue(1.0)]
         NormalAttack,
 
+        /// <summary>
+        /// An electric attack = 1.5
+        /// </summary>
         [ModifierValue(1.5)]
         ElectricAttack
     }
 
+    /// <summary>
+    /// Whether or not the attacker is crouching.  Might be able to be a bool in the future.
+    /// </summary>
     public enum CrouchingModifier
     {
+        /// <summary>
+        /// Is Crouching = 0.67
+        /// </summary>
         [ModifierValue(0.67)]
         Crouching,
 
+        /// <summary>
+        /// Is not crouching = 1.0
+        /// </summary>
         [ModifierValue(1.0)]
         NotCrouching
     }
 
+    /// <summary>
+    /// The type of shield advantage.
+    /// </summary>
     public enum ShieldAdvantageModifier
     {
+        /// <summary>
+        /// Default.
+        /// </summary>
         Regular,
+
+        /// <summary>
+        /// From projectile.
+        /// </summary>
         ProjectileNotHitlag
     }
 
+    /// <summary>
+    /// ControllerInput used.  Typically used with mashing out or determining grab duration.
+    /// </summary>
     public enum ControllerInput
     {
+        /// <summary>
+        /// Using the Left stick = 8.0
+        /// </summary>
         [ModifierValue(8.0)]
         LStick,
 
+        /// <summary>
+        /// Using buttons = 14.3
+        /// </summary>
         [ModifierValue(14.3)]
         Button
     }
 
+    /// <summary>
+    /// Controller input used when dealing with Pikmin grab duration.
+    /// </summary>
     public enum PikminGrabControllerInput
     {
+        /// <summary>
+        /// Left stick = 7.0
+        /// </summary>
         [ModifierValue(7.0)]
         LStick,
 
+        /// <summary>
+        /// Using buttons = 12.5
+        /// </summary>
         [ModifierValue(12.5)]
         Button
     }
-
+    
+    /// <summary>
+    /// The smash charge modifier.  Default is for holding a standard charge smash rather than no charge smash.  
+    /// </summary>
     public enum SmashChargeModifier
     {
+        /// <summary>
+        /// Default = 150.
+        /// </summary>
         [ModifierValue(150)]
         Default,
 
+        /// <summary>
+        /// Megaman's forward smash = 86.
+        /// </summary>
         [ModifierValue(86)]
         MegamanFSmash
     }
 
+    /// <summary>
+    /// The staleness of a move.  The higher the level the more stale the move is.
+    /// </summary>
     public enum StaleMoveNegationMultipler
     {
+        /// <summary>
+        /// S1 = 8.0
+        /// </summary>
         [ModifierValue(8.000)]
         S1,
 
+        /// <summary>
+        /// S2 = 7.594
+        /// </summary>
         [ModifierValue(7.594)]
         S2,
 
+        /// <summary>
+        /// S3 = 6.782
+        /// </summary>
         [ModifierValue(6.782)]
         S3,
 
+        /// <summary>
+        /// S4 = 6.028
+        /// </summary>
         [ModifierValue(6.028)]
         S4,
 
+        /// <summary>
+        /// S5 = 5.274
+        /// </summary>
         [ModifierValue(5.274)]
         S5,
 
+        /// <summary>
+        /// S6 = 4.462
+        /// </summary>
         [ModifierValue(4.462)]
         S6,
 
+        /// <summary>
+        /// S7 = 3.766
+        /// </summary>
         [ModifierValue(3.766)]
         S7,
 
+        /// <summary>
+        /// S8 = 2.954
+        /// </summary>
         [ModifierValue(2.954)]
         S8,
 
+        /// <summary>
+        /// S9 = 2.2
+        /// </summary>
         [ModifierValue(2.200)]
         S9
     }

--- a/KuroganeHammer.Data.Core/Calculations/Modifiers.cs
+++ b/KuroganeHammer.Data.Core/Calculations/Modifiers.cs
@@ -18,7 +18,7 @@ namespace KuroganeHammer.Data.Core.Calculations
 
     public static class ModifierHelper
     {
-        public static double GetModifierValue(this Modifiers modifier)
+        public static double GetModifierValue(this Enum modifier)
         {
             var modifierName = modifier.ToString();
             var type = modifier.GetType();
@@ -46,7 +46,10 @@ namespace KuroganeHammer.Data.Core.Calculations
 
     public enum ElectricModifier
     {
+        [ModifierValue(1.0)]
         NormalAttack,
+
+        [ModifierValue(1.5)]
         ElectricAttack
     }
 

--- a/KuroganeHammer.Data.Core/Calculations/Modifiers.cs
+++ b/KuroganeHammer.Data.Core/Calculations/Modifiers.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace KuroganeHammer.Data.Core.Calculations
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class ModifierValueAttribute : Attribute
+    {
+        public double Value { get; }
+
+        public ModifierValueAttribute(double value)
+        {
+            Guard.VerifyObjectNotNull(value, nameof(value));
+            Value = value;
+        }
+    }
+
+    public static class ModifierHelper
+    {
+        public static double GetModifierValue(this Modifiers modifier)
+        {
+            var modifierName = modifier.ToString();
+            var type = modifier.GetType();
+            var memInfo = type.GetMember(modifierName);
+            var valueAttribute = memInfo.Single(m => m.Name.Equals(modifierName)).GetCustomAttribute<ModifierValueAttribute>();
+
+            return valueAttribute.Value;
+        }
+    }
+
+    public enum Modifiers
+    {
+        [ModifierValue(1.0)]
+        Standing,
+
+        [ModifierValue(1.2)]
+        ChargingSmash,
+
+        [ModifierValue(0.85)]
+        CrouchCancelling,
+
+        [ModifierValue(0.8)]
+        GroundedMeteor
+    }
+
+    public enum ElectricModifier
+    {
+        NormalAttack,
+        ElectricAttack
+    }
+
+    public enum HitlagModifierType
+    {
+        Crouching,
+        NotCrouching
+    }
+
+    public enum ShieldAdvantageModifier
+    {
+        Regular,
+        Projectile_NotHitlag
+    }
+}

--- a/KuroganeHammer.Data.Core/Calculations/Modifiers.cs
+++ b/KuroganeHammer.Data.Core/Calculations/Modifiers.cs
@@ -29,6 +29,19 @@ namespace KuroganeHammer.Data.Core.Calculations
         }
     }
 
+    /// <summary>
+    /// Determines which hitbox is having data resolved in the equation.  Really important at the 
+    /// public request level in the api.  Otherwise it would be nightmare to act on all of them.
+    /// </summary>
+    public enum HitboxOptions
+    {
+        First,
+        Second,
+        Third,
+        Fourth,
+        Fifth
+    }
+
     public enum Modifiers
     {
         [ModifierValue(1.0)]
@@ -65,7 +78,7 @@ namespace KuroganeHammer.Data.Core.Calculations
     public enum ShieldAdvantageModifier
     {
         Regular,
-        Projectile_NotHitlag
+        ProjectileNotHitlag
     }
 
     public enum ControllerInput

--- a/KuroganeHammer.Data.Core/Calculations/ProblemModels.cs
+++ b/KuroganeHammer.Data.Core/Calculations/ProblemModels.cs
@@ -27,8 +27,52 @@ namespace KuroganeHammer.Data.Core.Calculations
         public double StaleMoveMultiplier { get; set; }
     }
 
-    public class ShieldStunNormalProblemData
+    public class HitlagProblemData
     {
-        
+        public double Damage { get; set; }
+        public double HitlagMultiplier { get; set; }
+        public ElectricModifier ElectricModifier { get; set; }
+        public CrouchingModifier CrouchingModifier { get; set; }
+    }
+
+    public class ShieldAdvantageProblemData
+    {
+        public int HitFrame { get; set; }
+        public int FirstActionableFrame { get; set; }
+        public int ShieldStun { get; set; }
+        public ShieldAdvantageModifier ShieldAdvantageModifier { get; set; }
+        //public int ShieldHitlag { get; set; }
+        public HitlagProblemData HitlagData { get; set; }
+        public int Hitlag { get; set; }
+    }
+
+    public class LedgeIntangiblityProblemData
+    {
+        public int AirborneFrames { get; set; }
+        public int CharacterPercentage { get; set; }
+    }
+
+    public class ReboundDurationProblemData
+    {
+        public int Damage { get; set; }
+    }
+
+    public class GrabDurationProblemData
+    {
+        public int TargetPercent { get; set; }
+        public ControllerInput Input { get; set; }
+    }
+
+    public class PikminGrabDurationProblemData
+    {
+        public int TargetPercent { get; set; }
+        public PikminGrabControllerInput Input { get; set; }
+    }
+
+    public class SmashChargeProblemData
+    {
+        public int Damage { get; set; }
+        public int HeldFrames { get; set; }
+        public SmashChargeModifier SmashChargeModifier { get; set; } = SmashChargeModifier.Default;
     }
 }

--- a/KuroganeHammer.Data.Core/Calculations/ProblemModels.cs
+++ b/KuroganeHammer.Data.Core/Calculations/ProblemModels.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KuroganeHammer.Data.Core.Calculations
+{
+    public class TrainingModeKnockbackProblemData
+    {
+        public double VictimPercent { get; set; }
+        public int BaseDamage { get; set; }
+        public double TargetWeight { get; set; }
+        public double KnockbackGrowth { get; set; }
+        public int BaseKnockbackSetKnockback { get; set; }
+        public double StanceModifier { get; set; }
+    }
+
+    public class VersusModeKnockbackProblemData
+    {
+        public double VictimPercent { get; set; }
+        public int BaseDamage { get; set; }
+        public double TargetWeight { get; set; }
+        public double KnockbackGrowth { get; set; }
+        public int BaseKnockbackSetKnockback { get; set; }
+        public double StanceModifier { get; set; }
+        public double StaleMoveMultiplier { get; set; }
+    }
+
+    public class ShieldStunNormalProblemData
+    {
+        
+    }
+}

--- a/KuroganeHammer.Data.Core/Calculations/ProblemModels.cs
+++ b/KuroganeHammer.Data.Core/Calculations/ProblemModels.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace KuroganeHammer.Data.Core.Calculations
+﻿namespace KuroganeHammer.Data.Core.Calculations
 {
     public class TrainingModeKnockbackProblemData
     {
@@ -16,10 +10,16 @@ namespace KuroganeHammer.Data.Core.Calculations
         public double StanceModifier { get; set; }
     }
 
+    public class RageProblemData
+    {
+        public double AttackerPercent { get; set; }
+    }
+
     public class VersusModeKnockbackProblemData
     {
+        public double AttackerPercent { get; set; }
         public double VictimPercent { get; set; }
-        public int BaseDamage { get; set; }
+        public double BaseDamage { get; set; }
         public double TargetWeight { get; set; }
         public double KnockbackGrowth { get; set; }
         public int BaseKnockbackSetKnockback { get; set; }

--- a/KuroganeHammer.Data.Core/KuroganeHammer.Data.Core.csproj
+++ b/KuroganeHammer.Data.Core/KuroganeHammer.Data.Core.csproj
@@ -43,6 +43,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="nunit.framework">
+      <HintPath>..\KuroganeHammer.Data\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.configuration" />
@@ -57,6 +60,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AerialStat.cs" />
+    <Compile Include="Calculations\Calculator.cs" />
+    <Compile Include="Calculations\Modifiers.cs" />
     <Compile Include="CharacterAttributes.cs" />
     <Compile Include="CharacterStat.cs" />
     <Compile Include="CharacterUtility.cs" />
@@ -70,6 +75,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SpecialStat.cs" />
     <Compile Include="Stat.cs" />
+    <Compile Include="Tests\CalculateTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/KuroganeHammer.Data.Core/KuroganeHammer.Data.Core.csproj
+++ b/KuroganeHammer.Data.Core/KuroganeHammer.Data.Core.csproj
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\KuroganeHammer.Data.Core.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/KuroganeHammer.Data.Core/KuroganeHammer.Data.Core.csproj
+++ b/KuroganeHammer.Data.Core/KuroganeHammer.Data.Core.csproj
@@ -62,6 +62,7 @@
     <Compile Include="AerialStat.cs" />
     <Compile Include="Calculations\Calculator.cs" />
     <Compile Include="Calculations\Modifiers.cs" />
+    <Compile Include="Calculations\ProblemModels.cs" />
     <Compile Include="CharacterAttributes.cs" />
     <Compile Include="CharacterStat.cs" />
     <Compile Include="CharacterUtility.cs" />

--- a/KuroganeHammer.Data.Core/Tests/CalculateTest.cs
+++ b/KuroganeHammer.Data.Core/Tests/CalculateTest.cs
@@ -7,27 +7,79 @@ namespace KuroganeHammer.Data.Core.Tests
     public class CalculateTest
     {
         private Calculator _calculator;
+        private TrainingModeKnockbackProblemData _trainingModeKnockbackData;
+        private VersusModeKnockbackProblemData _versusModeKnockbackData;
 
         [SetUp]
         public void SetUp()
         {
             _calculator = new Calculator();
+            _trainingModeKnockbackData = new TrainingModeKnockbackProblemData
+            {
+                VictimPercent = 100,
+                BaseDamage = 20,
+                TargetWeight = 80,
+                KnockbackGrowth = 10,
+                BaseKnockbackSetKnockback = 31,
+                StanceModifier = 1
+            };
+
+            _versusModeKnockbackData = new VersusModeKnockbackProblemData
+            {
+                VictimPercent = 100,
+                BaseDamage = 20,
+                TargetWeight = 80,
+                KnockbackGrowth = 10,
+                BaseKnockbackSetKnockback = 31,
+                StanceModifier = 1,
+                StaleMoveMultiplier = 0
+            };
         }
 
         [Test]
         public void ShouldGetExpectedTrainingModeKnockback()
         {
-            var result = _calculator.TrainingModeKnockback(100, 20, 80, 10, 31, 1);
-
+            var result = _calculator.TrainingModeKnockback(_trainingModeKnockbackData);
             Assert.That(result, Is.EqualTo(53.333333333333336d));
         }
 
         [Test]
         public void ShouldGetExpectedVersusModeKnockback()
         {
-            var result = _calculator.VersusModeKnockback(100, 20, 0, 80, 10, 31, 1);
-
+            var result = _calculator.VersusModeKnockback(_versusModeKnockbackData);
             Assert.That(result, Is.EqualTo(49.080386473429961d));
+        }
+
+        [Test]
+        public void ShouldGetExpectedTrainingModeHitstun()
+        {
+            var trainingModeKnockback = _calculator.TrainingModeKnockback(_trainingModeKnockbackData);
+            var result = _calculator.Hitstun(trainingModeKnockback);
+            Assert.That(result, Is.EqualTo(20));
+        }
+
+        [Test]
+        public void ShouldGetExpectedVersusModeHitstun()
+        {
+            var versusModeKnockback = _calculator.VersusModeKnockback(_versusModeKnockbackData);
+            var result = _calculator.Hitstun(versusModeKnockback);
+            Assert.That(result, Is.EqualTo(18));
+        }
+
+        [Test]
+        [TestCase(8.0, 6)]
+        [TestCase(25.5, 16)]
+        public void ShouldGetExpectedShieldstun_Normal(double damage, int expectedShieldstun)
+        {
+            var result = _calculator.ShieldStunNormal(damage);
+            Assert.That(result, Is.EqualTo(expectedShieldstun));
+        }
+
+        [Test]
+        public void ShouldGetExpectedRage()
+        {
+            var result = _calculator.Rage(100);
+            Assert.That(result, Is.EqualTo(1.0847826086956522d));
         }
 
         [Test]

--- a/KuroganeHammer.Data.Core/Tests/CalculateTest.cs
+++ b/KuroganeHammer.Data.Core/Tests/CalculateTest.cs
@@ -50,7 +50,7 @@ namespace KuroganeHammer.Data.Core.Tests
         public void ShouldGetExpectedVersusModeKnockback()
         {
             var result = _calculator.VersusModeKnockback(_versusModeKnockbackData);
-            Assert.That(result, Is.EqualTo(49.080386473429961d));
+            Assert.That(result, Is.EqualTo(45.244444444444447d));
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace KuroganeHammer.Data.Core.Tests
         {
             var versusModeKnockback = _calculator.VersusModeKnockback(_versusModeKnockbackData);
             var result = _calculator.Hitstun(versusModeKnockback);
-            Assert.That(result, Is.EqualTo(18));
+            Assert.That(result, Is.EqualTo(17));
         }
 
         [Test]

--- a/KuroganeHammer.Data.Core/Tests/CalculateTest.cs
+++ b/KuroganeHammer.Data.Core/Tests/CalculateTest.cs
@@ -201,7 +201,7 @@ namespace KuroganeHammer.Data.Core.Tests
                 HitFrame = 20,
                 Hitlag = 11,
                 ShieldStun = 13,
-                ShieldAdvantageModifier = ShieldAdvantageModifier.Projectile_NotHitlag,
+                ShieldAdvantageModifier = ShieldAdvantageModifier.ProjectileNotHitlag,
                 HitlagData = new HitlagProblemData
                 {
                     CrouchingModifier = CrouchingModifier.NotCrouching,
@@ -218,7 +218,7 @@ namespace KuroganeHammer.Data.Core.Tests
         [Test]
         public void ShouldGetExpectedRage()
         {
-            var result = _calculator.Rage(100);
+            var result = _calculator.Rage(new RageProblemData { AttackerPercent = 100 });
             Assert.That(result, Is.EqualTo(1.0847826086956522d));
         }
 

--- a/KuroganeHammer.Data.Core/Tests/CalculateTest.cs
+++ b/KuroganeHammer.Data.Core/Tests/CalculateTest.cs
@@ -6,13 +6,28 @@ namespace KuroganeHammer.Data.Core.Tests
     [TestFixture]
     public class CalculateTest
     {
+        private Calculator _calculator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _calculator = new Calculator();
+        }
+
         [Test]
         public void ShouldGetExpectedTrainingModeKnockback()
         {
-            var calculate = new Calculator();
-            var result = calculate.TrainingModeKnockback(100, 20, 80, 10, 31, 1);
+            var result = _calculator.TrainingModeKnockback(100, 20, 80, 10, 31, 1);
 
             Assert.That(result, Is.EqualTo(53.333333333333336d));
+        }
+
+        [Test]
+        public void ShouldGetExpectedVersusModeKnockback()
+        {
+            var result = _calculator.VersusModeKnockback(100, 20, 0, 80, 10, 31, 1);
+
+            Assert.That(result, Is.EqualTo(49.080386473429961d));
         }
 
         [Test]
@@ -20,9 +35,17 @@ namespace KuroganeHammer.Data.Core.Tests
         [TestCase(Modifiers.CrouchCancelling, 0.85)]
         [TestCase(Modifiers.GroundedMeteor, 0.8)]
         [TestCase(Modifiers.Standing, 1)]
-        public void ShouldGetValueAttributeFromModifier_ChargingSmash(Modifiers modifier, double expectedValue)
+        public void ShouldGetValueAttributeFromModifier(Modifiers modifier, double expectedValue)
         {
             Assert.That(modifier.GetModifierValue(), Is.EqualTo(expectedValue));
+        }
+
+        [Test]
+        [TestCase(ElectricModifier.NormalAttack, 1)]
+        [TestCase(ElectricModifier.ElectricAttack, 1.5)]
+        public void ShouldGetValueAttributeFromElectricModifier(ElectricModifier electricModifier, double expectedValue)
+        {
+            Assert.That(electricModifier.GetModifierValue(), Is.EqualTo(expectedValue));
         }
     }
 }

--- a/KuroganeHammer.Data.Core/Tests/CalculateTest.cs
+++ b/KuroganeHammer.Data.Core/Tests/CalculateTest.cs
@@ -1,0 +1,28 @@
+﻿using KuroganeHammer.Data.Core.Calculations;
+using NUnit.Framework;
+
+namespace KuroganeHammer.Data.Core.Tests
+{
+    [TestFixture]
+    public class CalculateTest
+    {
+        [Test]
+        public void ShouldGetExpectedTrainingModeKnockback()
+        {
+            var calculate = new Calculator();
+            var result = calculate.TrainingModeKnockback(100, 20, 80, 10, 31, 1);
+
+            Assert.That(result, Is.EqualTo(53.333333333333336d));
+        }
+
+        [Test]
+        [TestCase(Modifiers.ChargingSmash, 1.2)]
+        [TestCase(Modifiers.CrouchCancelling, 0.85)]
+        [TestCase(Modifiers.GroundedMeteor, 0.8)]
+        [TestCase(Modifiers.Standing, 1)]
+        public void ShouldGetValueAttributeFromModifier_ChargingSmash(Modifiers modifier, double expectedValue)
+        {
+            Assert.That(modifier.GetModifierValue(), Is.EqualTo(expectedValue));
+        }
+    }
+}

--- a/KuroganeHammer.Data.Core/Tests/CalculateTest.cs
+++ b/KuroganeHammer.Data.Core/Tests/CalculateTest.cs
@@ -1,4 +1,5 @@
-﻿using KuroganeHammer.Data.Core.Calculations;
+﻿using System;
+using KuroganeHammer.Data.Core.Calculations;
 using NUnit.Framework;
 
 namespace KuroganeHammer.Data.Core.Tests
@@ -34,6 +35,8 @@ namespace KuroganeHammer.Data.Core.Tests
                 StanceModifier = 1,
                 StaleMoveMultiplier = 0
             };
+
+
         }
 
         [Test]
@@ -76,6 +79,143 @@ namespace KuroganeHammer.Data.Core.Tests
         }
 
         [Test]
+        [TestCase(8.0, 5)]
+        [TestCase(25.5, 11)]
+        public void ShouldGetExpectedShieldstun_Powershield(double damage, int expectedShieldstun)
+        {
+            var result = _calculator.ShieldStunPowerShield(damage);
+            Assert.That(result, Is.EqualTo(expectedShieldstun));
+        }
+
+        [Test]
+        [TestCase(8.0, 4)]
+        [TestCase(25.5, 9)]
+        public void ShouldGetExpectedShieldstun_Projectile(double damage, int expectedShieldstun)
+        {
+            var result = _calculator.ShieldStunProjectile(damage);
+            Assert.That(result, Is.EqualTo(expectedShieldstun));
+        }
+
+        [Test]
+        [TestCase(8.0, 3)]
+        [TestCase(25.5, 6)]
+        public void ShouldGetExpectedShieldstun_Powershield_Projectile(double damage, int expectedShieldstun)
+        {
+            var result = _calculator.ShieldStunPowerShieldProjectile(damage);
+            Assert.That(result, Is.EqualTo(expectedShieldstun));
+        }
+
+        [Test]
+        public void ShouldGetExpectedHitlag_NotCrouching_NormalAttack()
+        {
+            var hitlagData = new HitlagProblemData
+            {
+                Damage = 20,
+                CrouchingModifier = CrouchingModifier.NotCrouching,
+                ElectricModifier = ElectricModifier.NormalAttack,
+                HitlagMultiplier = 1
+            };
+
+            var result = _calculator.Hitlag(hitlagData);
+            Assert.That(result, Is.EqualTo(11));
+        }
+
+        [Test]
+        public void ShouldGetExpectedHitlag_NotCrouching_ElectricAttack()
+        {
+            var hitlagData = new HitlagProblemData
+            {
+                Damage = 20,
+                CrouchingModifier = CrouchingModifier.NotCrouching,
+                ElectricModifier = ElectricModifier.ElectricAttack,
+                HitlagMultiplier = 1
+            };
+
+            var result = _calculator.Hitlag(hitlagData);
+            Assert.That(result, Is.EqualTo(18));
+        }
+
+        [Test]
+        [TestCase(20, CrouchingModifier.NotCrouching, ElectricModifier.NormalAttack, 1, 11)]
+        [TestCase(20, CrouchingModifier.NotCrouching, ElectricModifier.NormalAttack, 2, 24)]
+        [TestCase(20, CrouchingModifier.Crouching, ElectricModifier.ElectricAttack, 1, 11)]
+        [TestCase(20, CrouchingModifier.Crouching, ElectricModifier.ElectricAttack, 2, 24)]
+        public void ShouldGetExpectedHitlag(double damage, CrouchingModifier crouchModifier,
+            ElectricModifier elecModifier, double hitlagMultiplier, int expectedResult)
+        {
+            var hitlagData = new HitlagProblemData
+            {
+                Damage = damage,
+                CrouchingModifier = crouchModifier,
+                ElectricModifier = elecModifier,
+                HitlagMultiplier = hitlagMultiplier
+            };
+
+            var result = _calculator.Hitlag(hitlagData);
+            Assert.That(result, Is.EqualTo(expectedResult));
+        }
+
+        public void ShouldReturn30HitlagWhenHitlagMoreThan30()
+        {
+            var hitlagData = new HitlagProblemData
+            {
+                Damage = 50,
+                CrouchingModifier = CrouchingModifier.NotCrouching,
+                ElectricModifier = ElectricModifier.NormalAttack,
+                HitlagMultiplier = 2
+            };
+
+            var result = _calculator.Hitlag(hitlagData);
+            Assert.That(result, Is.EqualTo(30));
+        }
+
+        [Test]
+        public void ShouldGetExpectedShieldAdvantage_Normal()
+        {
+            var data = new ShieldAdvantageProblemData
+            {
+                FirstActionableFrame = 22,
+                HitFrame = 20,
+                Hitlag = 11,
+                ShieldStun = 13,
+                ShieldAdvantageModifier = ShieldAdvantageModifier.Regular,
+                HitlagData = new HitlagProblemData
+                {
+                    CrouchingModifier = CrouchingModifier.NotCrouching,
+                    Damage = 20,
+                    ElectricModifier = ElectricModifier.NormalAttack,
+                    HitlagMultiplier = 1
+                }
+            };
+
+            var result = _calculator.ShieldAdvantage(data);
+            Assert.That(result, Is.EqualTo(12));
+        }
+
+        [Test]
+        public void ShouldGetExpectedShieldAdvantage_Normal_Projectile_NotHitlag()
+        {
+            var data = new ShieldAdvantageProblemData
+            {
+                FirstActionableFrame = 22,
+                HitFrame = 20,
+                Hitlag = 11,
+                ShieldStun = 13,
+                ShieldAdvantageModifier = ShieldAdvantageModifier.Projectile_NotHitlag,
+                HitlagData = new HitlagProblemData
+                {
+                    CrouchingModifier = CrouchingModifier.NotCrouching,
+                    Damage = 20,
+                    ElectricModifier = ElectricModifier.NormalAttack,
+                    HitlagMultiplier = 1
+                }
+            };
+
+            var result = _calculator.ShieldAdvantage(data);
+            Assert.That(result, Is.EqualTo(24), "Fail expected.  Bug in official calc up where it doesn't Floor when proj shield adv mod.");
+        }
+
+        [Test]
         public void ShouldGetExpectedRage()
         {
             var result = _calculator.Rage(100);
@@ -98,6 +238,103 @@ namespace KuroganeHammer.Data.Core.Tests
         public void ShouldGetValueAttributeFromElectricModifier(ElectricModifier electricModifier, double expectedValue)
         {
             Assert.That(electricModifier.GetModifierValue(), Is.EqualTo(expectedValue));
+        }
+
+        [Test]
+        public void ShouldGetExpectedLedgeIntangibility()
+        {
+            var data = new LedgeIntangiblityProblemData
+            {
+                AirborneFrames = 50,
+                CharacterPercentage = 70
+            };
+
+            var result = _calculator.LedgeIntangibility(data);
+            Assert.That(result, Is.EqualTo(48));
+        }
+
+        [Test]
+        public void ShouldThrowExceptionForAirFramesOver300_LedgeIntangibility()
+        {
+            var data = new LedgeIntangiblityProblemData
+            {
+                AirborneFrames = 301,
+                CharacterPercentage = 80
+            };
+
+            Assert.Throws<Exception>(() => _calculator.LedgeIntangibility(data));
+        }
+
+        [Test]
+        public void ShouldThrowExceptionForCharacterPercentageOver120()
+        {
+            var data = new LedgeIntangiblityProblemData
+            {
+                AirborneFrames = 30,
+                CharacterPercentage = 121
+            };
+
+            Assert.Throws<Exception>(() => _calculator.LedgeIntangibility(data));
+        }
+
+        [Test]
+        [Ignore("Need to contact spacejam about this formula")]
+        public void ShouldGetExpectedReboundDuration()
+        {
+            var data = new ReboundDurationProblemData
+            {
+                Damage = 50
+            };
+
+            var result = _calculator.ReboundDuration(data);
+
+            //Assert.That(result, Is.EqualTo())
+        }
+
+        [Test]
+        [TestCase(ControllerInput.LStick, 116)]
+        [TestCase(ControllerInput.Button, 109)]
+        public void ShouldGetExpectedGrabDuration(ControllerInput input, int expectedFrames)
+        {
+            var data = new GrabDurationProblemData
+            {
+                Input = input,
+                TargetPercent = 20
+            };
+
+            var result = _calculator.GrabDuration(data);
+            Assert.That(result, Is.EqualTo(expectedFrames));
+        }
+
+        [Test]
+        [TestCase(PikminGrabControllerInput.LStick, 333)]
+        [TestCase(PikminGrabControllerInput.Button, 327)]
+        public void ShouldGetExpectedPikminGrabDuration(PikminGrabControllerInput input, int expectedFrames)
+        {
+            var data = new PikminGrabDurationProblemData
+            {
+                Input = input,
+                TargetPercent = 20
+            };
+
+            var result = _calculator.PikminGrabDuration(data);
+            Assert.That(result, Is.EqualTo(expectedFrames));
+        }
+
+        [Test]
+        [TestCase(SmashChargeModifier.Default, 13)]
+        [TestCase(SmashChargeModifier.MegamanFSmash, 23)]
+        public void ShouldGetExpectedSmashCharge(SmashChargeModifier chargeModifier, int expected)
+        {
+            var data = new SmashChargeProblemData
+            {
+                Damage = 40,
+                HeldFrames = 50,
+                SmashChargeModifier = chargeModifier
+            };
+
+            var result = _calculator.SmashCharge(data);
+            Assert.That(result, Is.EqualTo(expected));
         }
     }
 }

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Controllers/BaseControllerTest.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Controllers/BaseControllerTest.cs
@@ -26,6 +26,7 @@ namespace KuroganeHammer.Data.Api.Tests.Controllers
         protected CharacterAttributesController CharacterAttributesController;
         protected CharacterAttributeTypesController CharacterAttributeTypesController;
         protected NotationsController NotationsController;
+        protected CalculatorController CalculatorController;
         protected TestObjects TestObjects;
 
         [SetUp]
@@ -40,6 +41,7 @@ namespace KuroganeHammer.Data.Api.Tests.Controllers
             CharacterAttributesController = new CharacterAttributesController(DbContext);
             CharacterAttributeTypesController = new CharacterAttributeTypesController(DbContext);
             NotationsController = new NotationsController(DbContext);
+            CalculatorController = new CalculatorController(DbContext);
             TestObjects = new TestObjects();
 
             _server = TestServer.Create(app =>

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Controllers/Calculator/CalculatorCrudControllerTest.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Controllers/Calculator/CalculatorCrudControllerTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Web.Http.Results;
 using KuroganeHammer.Data.Api.Models;
+using KuroganeHammer.Data.Core.Calculations;
 using NUnit.Framework;
 
 namespace KuroganeHammer.Data.Api.Tests.Controllers.Calculator
@@ -7,17 +8,6 @@ namespace KuroganeHammer.Data.Api.Tests.Controllers.Calculator
     [TestFixture]
     public class CalculatorCrudControllerTest : BaseControllerTest
     {
-        [Test]
-        public void ShouldReturnExpectedCalculation()
-        {
-            CalculatorRequestModel calcRequest = TestObjects.CalcRequest();
-
-            var response = CalculatorController.PostCalculatorRequest(calcRequest) as OkNegotiatedContentResult<CalculatorResponseModel>;
-
-            Assert.That(response?.Content, Is.Not.Null);
-
-            var content = response.Content;
-            Assert.That(content.TrainingModeKnockback, Is.EqualTo(53.333333333333336d));
-        }
+       
     }
 }

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Controllers/Calculator/CalculatorCrudControllerTest.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Controllers/Calculator/CalculatorCrudControllerTest.cs
@@ -1,0 +1,23 @@
+﻿using System.Web.Http.Results;
+using KuroganeHammer.Data.Api.Models;
+using NUnit.Framework;
+
+namespace KuroganeHammer.Data.Api.Tests.Controllers.Calculator
+{
+    [TestFixture]
+    public class CalculatorCrudControllerTest : BaseControllerTest
+    {
+        [Test]
+        public void ShouldReturnExpectedCalculation()
+        {
+            CalculatorRequestModel calcRequest = TestObjects.CalcRequest();
+
+            var response = CalculatorController.PostCalculatorRequest(calcRequest) as OkNegotiatedContentResult<CalculatorResponseModel>;
+
+            Assert.That(response?.Content, Is.Not.Null);
+
+            var content = response.Content;
+            Assert.That(content.TrainingModeKnockback, Is.EqualTo(53.333333333333336d));
+        }
+    }
+}

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/KuroganeHammer.Data.Api.Tests.csproj
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/KuroganeHammer.Data.Api.Tests.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Controllers\SmashAttributeTypes\SmashAttributeTypeAuthenticatedControllerTest.cs" />
     <Compile Include="Controllers\SmashAttributeTypes\SmashAttributeTypesControllerTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Smoke\CalculatorSmokeTest.cs" />
     <Compile Include="Smoke\CharacterAttributeSmokeTest.cs" />
     <Compile Include="Smoke\CharacterSmokeTest.cs" />
     <Compile Include="Smoke\LoginSmokeTest.cs" />

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/KuroganeHammer.Data.Api.Tests.csproj
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/KuroganeHammer.Data.Api.Tests.csproj
@@ -181,6 +181,35 @@
       <Name>KuroganeHammer.Data.Api</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <COMReference Include="Microsoft.Office.Core">
+      <Guid>{2DF8D04C-5BFA-101B-BDE5-00AA0044DE52}</Guid>
+      <VersionMajor>2</VersionMajor>
+      <VersionMinor>8</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>primary</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
+    <COMReference Include="Microsoft.Office.Interop.Excel">
+      <Guid>{00020813-0000-0000-C000-000000000046}</Guid>
+      <VersionMajor>1</VersionMajor>
+      <VersionMinor>9</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>primary</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
+    <COMReference Include="VBIDE">
+      <Guid>{0002E157-0000-0000-C000-000000000046}</Guid>
+      <VersionMajor>5</VersionMajor>
+      <VersionMinor>3</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>primary</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/KuroganeHammer.Data.Api.Tests.csproj
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/KuroganeHammer.Data.Api.Tests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Controllers\Accounts\AccountsControllerTest.cs" />
     <Compile Include="Controllers\BaseAuthenticatedTest.cs" />
     <Compile Include="Controllers\BaseControllerTest.cs" />
+    <Compile Include="Controllers\Calculator\CalculatorCrudControllerTest.cs" />
     <Compile Include="Controllers\CharacterAttributes\CharacterAttributeAnonymousControllerTest.cs" />
     <Compile Include="Controllers\CharacterAttributes\CharacterAttributeCrudControllerTest.cs" />
     <Compile Include="Controllers\CharacterAttributes\CharacterAttributesAuthenticatedControllerTest.cs" />
@@ -170,6 +171,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\KuroganeHammer.Data.Core\KuroganeHammer.Data.Core.csproj">
+      <Project>{2904D4E7-8989-46BD-AC0A-B4356F190A15}</Project>
+      <Name>KuroganeHammer.Data.Core</Name>
+    </ProjectReference>
     <ProjectReference Include="..\KuroganeHammer.Data.Api\KuroganeHammer.Data.Api.csproj">
       <Project>{470ADA5B-56B2-45D3-8162-AB65B0350C68}</Project>
       <Name>KuroganeHammer.Data.Api</Name>

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/CalculatorSmokeTest.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/CalculatorSmokeTest.cs
@@ -1,4 +1,7 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
 using System.Threading.Tasks;
 using KuroganeHammer.Data.Api.DTOs;
 using KuroganeHammer.Data.Api.Models;
@@ -27,14 +30,124 @@ namespace KuroganeHammer.Data.Api.Tests.Smoke
                 VictimDamagePercent = 70
             };
 
-            var response = await LoggedInBasicClient.PostAsJsonAsync(Baseuri + CalculatorRoute + "/moves/vsknockback", requestModel);
+            var response =
+                await
+                    LoggedInBasicClient.PostAsJsonAsync(Baseuri + CalculatorRoute + "/moves/vsknockback", requestModel);
 
             Assert.That(response.IsSuccessStatusCode);
 
             var result = await response.Content.ReadAsAsync<CompletedCalculationResponseDto>();
 
+            Assert.That(result.CharacterName, Is.EqualTo("Pikachu"));
+            Assert.That(result.CalculatedValueName, Is.EqualTo("VsModeKnockback"));
             Assert.That(result.MoveName, Is.EqualTo("Dash Attack"));
             Assert.That(result.CalculatedValue, Is.EqualTo(469.38543478260868d));
+        }
+
+        [Test]
+        public async Task WriteToCSVTest_VsModeKnockback()
+        {
+            var responses = new List<CompletedCalculationResponseDto>();
+
+            var moves = await LoggedInBasicClient.GetAsync(Baseuri + MovesRoute);
+
+            var movesContent = moves.Content.ReadAsAsync<List<MoveDto>>().Result;
+
+            foreach (var move in movesContent)
+            {
+                var requestModel = new CalculatorMoveModel
+                {
+                    AttackerDamagePercent = 100,
+                    CrouchingModifier = CrouchingModifier.NotCrouching,
+                    ElectricModifier = ElectricModifier.NormalAttack,
+                    HitboxOption = HitboxOptions.First,
+                    Modifiers = Modifiers.Standing,
+                    MoveId = move.Id,
+                    ShieldAdvantageModifier = ShieldAdvantageModifier.Regular,
+                    StaleMoveNegationMultiplier = StaleMoveNegationMultipler.S1,
+                    TargetWeight = 80,
+                    VictimDamagePercent = 70
+                };
+
+                var response =
+                    await
+                        LoggedInBasicClient.PostAsJsonAsync(Baseuri + CalculatorRoute + "/moves/vsknockback",
+                            requestModel);
+
+                //Assert.That(response.IsSuccessStatusCode);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var result = await response.Content.ReadAsAsync<CompletedCalculationResponseDto>();
+
+                    responses.Add(result);
+
+                }
+            }
+
+            using (StreamWriter writer = File.CreateText("test.csv"))
+            {
+                foreach (var result in responses)
+                {
+
+                    writer.WriteLine(
+                        $"{result.CharacterName}, {result.MoveName}, {result.CalculatedValueName}, {result.CalculatedValue}");
+                }
+            }
+
+        }
+
+        [Test]
+        public async Task WriteToCSVTest_Shieldstun_Normal()
+        {
+            var responses = new List<CompletedCalculationResponseDto>();
+
+            var moves = await LoggedInBasicClient.GetAsync(Baseuri + MovesRoute);
+
+            var movesContent = moves.Content.ReadAsAsync<List<MoveDto>>().Result;
+
+            foreach (var move in movesContent)
+            {
+                var requestModel = new CalculatorMoveModel
+                {
+                    AttackerDamagePercent = 100,
+                    CrouchingModifier = CrouchingModifier.NotCrouching,
+                    ElectricModifier = ElectricModifier.NormalAttack,
+                    HitboxOption = HitboxOptions.First,
+                    Modifiers = Modifiers.Standing,
+                    MoveId = move.Id,
+                    ShieldAdvantageModifier = ShieldAdvantageModifier.Regular,
+                    StaleMoveNegationMultiplier = StaleMoveNegationMultipler.S1,
+                    TargetWeight = 80,
+                    VictimDamagePercent = 70
+                };
+
+                var response =
+                    await
+                        LoggedInBasicClient.PostAsJsonAsync(Baseuri + CalculatorRoute + "/moves/shieldstunnormal",
+                            requestModel);
+
+                //Assert.That(response.IsSuccessStatusCode);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var result = await response.Content.ReadAsAsync<CompletedCalculationResponseDto>();
+
+                    responses.Add(result);
+
+                }
+            }
+
+            using (StreamWriter writer = File.CreateText("test.csv"))
+            {
+                foreach (var result in responses)
+                {
+
+                    writer.WriteLine(
+                        $"{result.CharacterName}, {result.MoveName}, {result.CalculatedValueName}, {result.CalculatedValue}");
+                }
+            }
+
         }
     }
 }

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/CalculatorSmokeTest.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/CalculatorSmokeTest.cs
@@ -45,6 +45,7 @@ namespace KuroganeHammer.Data.Api.Tests.Smoke
         }
 
         [Test]
+        [Explicit("Writes to csv file")]
         public async Task WriteToCSVTest_VsModeKnockback()
         {
             var responses = new List<CompletedCalculationResponseDto>();
@@ -76,16 +77,13 @@ namespace KuroganeHammer.Data.Api.Tests.Smoke
 
                 //Assert.That(response.IsSuccessStatusCode);
 
-                if (response.IsSuccessStatusCode)
-                {
-                    var result = await response.Content.ReadAsAsync<CompletedCalculationResponseDto>();
+                if (!response.IsSuccessStatusCode) continue;
+                var result = await response.Content.ReadAsAsync<CompletedCalculationResponseDto>();
 
-                    responses.Add(result);
-
-                }
+                responses.Add(result);
             }
 
-            using (StreamWriter writer = File.CreateText("test.csv"))
+            using (var writer = File.CreateText("test.csv"))
             {
                 foreach (var result in responses)
                 {
@@ -98,6 +96,7 @@ namespace KuroganeHammer.Data.Api.Tests.Smoke
         }
 
         [Test]
+        [Explicit("Writes to csv file")]
         public async Task WriteToCSVTest_Shieldstun_Normal()
         {
             var responses = new List<CompletedCalculationResponseDto>();
@@ -129,16 +128,13 @@ namespace KuroganeHammer.Data.Api.Tests.Smoke
 
                 //Assert.That(response.IsSuccessStatusCode);
 
-                if (response.IsSuccessStatusCode)
-                {
-                    var result = await response.Content.ReadAsAsync<CompletedCalculationResponseDto>();
+                if (!response.IsSuccessStatusCode) continue;
+                var result = await response.Content.ReadAsAsync<CompletedCalculationResponseDto>();
 
-                    responses.Add(result);
-
-                }
+                responses.Add(result);
             }
 
-            using (StreamWriter writer = File.CreateText("test.csv"))
+            using (var writer = File.CreateText("test.csv"))
             {
                 foreach (var result in responses)
                 {

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/CalculatorSmokeTest.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/CalculatorSmokeTest.cs
@@ -1,0 +1,38 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using KuroganeHammer.Data.Api.Models;
+using KuroganeHammer.Data.Core.Calculations;
+using NUnit.Framework;
+
+namespace KuroganeHammer.Data.Api.Tests.Smoke
+{
+    [TestFixture]
+    public class CalculatorSmokeTest : BaseSmokeTest
+    {
+        [Test]
+        public async Task ShouldReturnExpectedVersusKnockback()
+        {
+            var requestModel = new CalculatorMoveModel
+            {
+                AttackerDamagePercent = 100,
+                CrouchingModifier = CrouchingModifier.NotCrouching,
+                ElectricModifier = ElectricModifier.NormalAttack,
+                HitboxOption = HitboxOptions.First,
+                Modifiers = Modifiers.Standing,
+                MoveId = 2,
+                ShieldAdvantageModifier = ShieldAdvantageModifier.Regular,
+                StaleMoveNegationMultiplier = StaleMoveNegationMultipler.S1,
+                TargetWeight = 80,
+                VictimDamagePercent = 70
+            };
+
+            var response = await LoggedInBasicClient.PostAsJsonAsync(Baseuri + CalculatorRoute + "/moves/vsknockback", requestModel);
+
+            Assert.That(response.IsSuccessStatusCode);
+
+            var result = await response.Content.ReadAsAsync<double>();
+
+
+        }
+    }
+}

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/CalculatorSmokeTest.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/CalculatorSmokeTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
+using KuroganeHammer.Data.Api.DTOs;
 using KuroganeHammer.Data.Api.Models;
 using KuroganeHammer.Data.Core.Calculations;
 using NUnit.Framework;
@@ -30,9 +31,10 @@ namespace KuroganeHammer.Data.Api.Tests.Smoke
 
             Assert.That(response.IsSuccessStatusCode);
 
-            var result = await response.Content.ReadAsAsync<double>();
+            var result = await response.Content.ReadAsAsync<CompletedCalculationResponseDto>();
 
-
+            Assert.That(result.MoveName, Is.EqualTo("Dash Attack"));
+            Assert.That(result.CalculatedValue, Is.EqualTo(469.38543478260868d));
         }
     }
 }

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/CharacterAttributeSmokeTest.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/CharacterAttributeSmokeTest.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using KuroganeHammer.Data.Api.DTOs;
@@ -27,7 +26,7 @@ namespace KuroganeHammer.Data.Api.Tests.Smoke
         {
             CollectionAssert.AllItemsAreNotNull(_attributes);
             CollectionAssert.AllItemsAreUnique(_attributes);
-            CollectionPropertyAssert.AllPropertiesNotNullInCollection(_attributes, "SmashAttributeType");
+            CollectionPropertyAssert.AllPropertiesNotNullInCollection(_attributes, "CharacterAttributeType", "SmashAttributeType");
         }
 
         [Test]
@@ -65,11 +64,11 @@ namespace KuroganeHammer.Data.Api.Tests.Smoke
             CollectionAssert.AllItemsAreUnique(characterAttributeRows);
         }
 
-        [Test]
-        public async Task ShouldNotGetAllCharacterAttributesDueToNoAuth()
-        {
-            var result = await AnonymousClient.GetAsync(Baseuri + CharacterAttributeRoute);
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-        }
+        //[Test]
+        //public async Task ShouldNotGetAllCharacterAttributesDueToNoAuth()
+        //{
+        //    var result = await AnonymousClient.GetAsync(Baseuri + CharacterAttributeRoute);
+        //    Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        //}
     }
 }

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/MoveSmokeTest.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/MoveSmokeTest.cs
@@ -58,11 +58,11 @@ namespace KuroganeHammer.Data.Api.Tests.Smoke
             Assert.That(move.Name.Length > 0);
         }
 
-        [Test]
-        public async Task ShouldNotGetAllMovesDueToNoAuth()
-        {
-            var result = await AnonymousClient.GetAsync(Baseuri + MovesRoute);
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-        }
+        //[Test]
+        //public async Task ShouldNotGetAllMovesDueToNoAuth()
+        //{
+        //    var result = await AnonymousClient.GetAsync(Baseuri + MovesRoute);
+        //    Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        //}
     }
 }

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/MovementSmokeTest.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/MovementSmokeTest.cs
@@ -55,11 +55,11 @@ namespace KuroganeHammer.Data.Api.Tests.Smoke
             Assert.That(movement.Name.Length > 0);
         }
 
-        [Test]
-        public async Task ShouldNotGetAllMovementsDueToNoAuth()
-        {
-            var result = await AnonymousClient.GetAsync(Baseuri + MovementsRoute);
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-        }
+        //[Test]
+        //public async Task ShouldNotGetAllMovementsDueToNoAuth()
+        //{
+        //    var result = await AnonymousClient.GetAsync(Baseuri + MovementsRoute);
+        //    Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        //}
     }
 }

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/SmashAttributeTypeSmokeTest.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/SmashAttributeTypeSmokeTest.cs
@@ -38,11 +38,11 @@ namespace KuroganeHammer.Data.Api.Tests.Smoke
             Assert.That(attributeType.Name.Length > 0);
         }
 
-        [Test]
-        public async Task ShouldNotGetAllSmashAttributeTypesDueToNoAuth()
-        {
-            var result = await AnonymousClient.GetAsync(Baseuri + SmashAttributeTypeRoute);
-            Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-        }
+        //[Test]
+        //public async Task ShouldNotGetAllSmashAttributeTypesDueToNoAuth()
+        //{
+        //    var result = await AnonymousClient.GetAsync(Baseuri + SmashAttributeTypeRoute);
+        //    Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        //}
     }
 }

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/SmokeBaseTest.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/Smoke/SmokeBaseTest.cs
@@ -21,6 +21,7 @@ namespace KuroganeHammer.Data.Api.Tests.Smoke
         protected const string MovesRoute = "moves";
         protected const string SmashAttributeTypeRoute = "smashattributetypes";
         protected const string CharacterAttributeRoute = "characterattributes";
+        protected const string CalculatorRoute = "calculator";
 
         [SetUp]
         public virtual void SetUp()
@@ -44,6 +45,9 @@ namespace KuroganeHammer.Data.Api.Tests.Smoke
             });
 
             var adminresponse = LoggedInAdminClient.PostAsync(tokenUri, admincontent).Result;
+
+            var json = adminresponse.Content.ReadAsStringAsync().Result;
+
             _adminauthToken =
                 JsonConvert.DeserializeObject<dynamic>(adminresponse.Content.ReadAsStringAsync().Result).access_token;
             LoggedInAdminClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _adminauthToken);

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/TestObjects.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/TestObjects.cs
@@ -1,5 +1,6 @@
 ﻿using KuroganeHammer.Data.Api.Models;
 using System;
+using KuroganeHammer.Data.Core.Calculations;
 
 namespace KuroganeHammer.Data.Api.Tests
 {
@@ -139,6 +140,24 @@ namespace KuroganeHammer.Data.Api.Tests
             _characterAttributeCounter++;
 
             return characterAttribute;
+        }
+
+        public CalculatorRequestModel CalcRequest()
+        {
+            return new CalculatorRequestModel
+            {
+                AttackerPercent = 100,
+                VictimPercent = 100,
+                BaseDamage = 20,
+                TargetWeight = 80,
+                KnockbackGrowth = 10,
+                BaseKnockbackSetKnockback = 31,
+                HitlagModifier = 1,
+                HitFrame = 4,
+                FirstActiveFrame = 12,
+                Staleness = 0, 
+                Modifiers = Modifiers.Standing,
+            };
         }
     }
 }

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/TestObjects.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api.Tests/TestObjects.cs
@@ -142,22 +142,22 @@ namespace KuroganeHammer.Data.Api.Tests
             return characterAttribute;
         }
 
-        public CalculatorRequestModel CalcRequest()
-        {
-            return new CalculatorRequestModel
-            {
-                AttackerPercent = 100,
-                VictimPercent = 100,
-                BaseDamage = 20,
-                TargetWeight = 80,
-                KnockbackGrowth = 10,
-                BaseKnockbackSetKnockback = 31,
-                HitlagModifier = 1,
-                HitFrame = 4,
-                FirstActiveFrame = 12,
-                Staleness = 0, 
-                Modifiers = Modifiers.Standing,
-            };
-        }
+        //public CalculatorRequestModel CalcRequest()
+        //{
+        //    return new CalculatorRequestModel
+        //    {
+        //        AttackerPercent = 100,
+        //        VictimPercent = 100,
+        //        BaseDamage = 20,
+        //        TargetWeight = 80,
+        //        KnockbackGrowth = 10,
+        //        BaseKnockbackSetKnockback = 31,
+        //        HitlagModifier = 1,
+        //        HitFrame = 4,
+        //        FirstActiveFrame = 12,
+        //        Staleness = 0, 
+        //        Modifiers = Modifiers.Standing,
+        //    };
+        //}
     }
 }

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/App_Data/XmlDocument.xml
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/App_Data/XmlDocument.xml
@@ -38,6 +38,43 @@
             <param name="model"></param>
             <returns></returns>
         </member>
+        <member name="T:KuroganeHammer.Data.Api.Controllers.CalculatorController">
+            <summary>
+            Controller used for calculating data off of character attributes and properties such as moves.
+            </summary>
+        </member>
+        <member name="M:KuroganeHammer.Data.Api.Controllers.CalculatorController.#ctor">
+            <summary>
+            Creates a <see cref="T:KuroganeHammer.Data.Api.Controllers.CalculatorController"/> with the default <see cref="T:KuroganeHammer.Data.Api.Models.ApplicationDbContext"/>.
+            </summary>
+        </member>
+        <member name="M:KuroganeHammer.Data.Api.Controllers.CalculatorController.#ctor(KuroganeHammer.Data.Api.Models.ApplicationDbContext)">
+            <summary>
+            Creates a <see cref="T:KuroganeHammer.Data.Api.Controllers.CalculatorController"/> with the specified <see cref="T:KuroganeHammer.Data.Api.Models.ApplicationDbContext"/>.
+            </summary>
+            <param name="context"></param>
+        </member>
+        <member name="M:KuroganeHammer.Data.Api.Controllers.CalculatorController.PostRage(KuroganeHammer.Data.Core.Calculations.RageProblemData)">
+            <summary>
+            Calculate Rage based on passed in data.
+            </summary>
+            <param name="data"></param>
+            <returns></returns>
+        </member>
+        <member name="M:KuroganeHammer.Data.Api.Controllers.CalculatorController.PostMoveVsKnockback(KuroganeHammer.Data.Api.Models.CalculatorMoveModel)">
+            <summary>
+            Calculate Vs mode knockback of a specific character's move.
+            </summary>
+            <param name="model"></param>
+            <returns></returns>
+        </member>
+        <member name="M:KuroganeHammer.Data.Api.Controllers.CalculatorController.PostMoveShieldStunNormal(KuroganeHammer.Data.Api.Models.CalculatorMoveModel)">
+            <summary>
+            Calculate the Normal Shield stun of a specific character's move.
+            </summary>
+            <param name="model"></param>
+            <returns></returns>
+        </member>
         <member name="T:KuroganeHammer.Data.Api.Controllers.CharacterAttributesController">
             <summary>
             Handles all individual <see cref="T:KuroganeHammer.Data.Api.Models.CharacterAttribute"/> operations.  
@@ -417,6 +454,63 @@
              to change in the future it's fairly straightforward to do so on the back and the frontend won't 
             need to change as much (if at all).
             
+            </summary>
+        </member>
+        <member name="T:KuroganeHammer.Data.Api.Models.CalculatorMoveModel">
+            <summary>
+            Model used for performing calculations on character moves.
+            </summary>
+        </member>
+        <member name="P:KuroganeHammer.Data.Api.Models.CalculatorMoveModel.MoveId">
+            <summary>
+            The Id of the Move in question.
+            </summary>
+        </member>
+        <member name="P:KuroganeHammer.Data.Api.Models.CalculatorMoveModel.AttackerDamagePercent">
+            <summary>
+            The damage percent the attacker has.
+            </summary>
+        </member>
+        <member name="P:KuroganeHammer.Data.Api.Models.CalculatorMoveModel.VictimDamagePercent">
+            <summary>
+            The damage percent the target being hit has.
+            </summary>
+        </member>
+        <member name="P:KuroganeHammer.Data.Api.Models.CalculatorMoveModel.TargetWeight">
+            <summary>
+            The weight of the target.
+            </summary>
+        </member>
+        <member name="P:KuroganeHammer.Data.Api.Models.CalculatorMoveModel.StaleMoveNegationMultiplier">
+            <summary>
+            The stale move negation level.  More details on this found at: http://kuroganehammer.com/Smash4/Formulas.  
+            Default in no staleness on a move.
+            </summary>
+        </member>
+        <member name="P:KuroganeHammer.Data.Api.Models.CalculatorMoveModel.ElectricModifier">
+            <summary>
+            What type of attack is being performed.  More details on this found at: http://kuroganehammer.com/Smash4/Formulas.   
+            </summary>
+        </member>
+        <member name="P:KuroganeHammer.Data.Api.Models.CalculatorMoveModel.CrouchingModifier">
+            <summary>
+            Whether or not the target being hit is crouching or otherwise.  More details on this found at: http://kuroganehammer.com/Smash4/Formulas.  
+            </summary>
+        </member>
+        <member name="P:KuroganeHammer.Data.Api.Models.CalculatorMoveModel.ShieldAdvantageModifier">
+            <summary>
+            Shield advantage modifier based on normal or projectile.  More details on this found at: http://kuroganehammer.com/Smash4/Formulas.  
+            </summary>
+        </member>
+        <member name="P:KuroganeHammer.Data.Api.Models.CalculatorMoveModel.Modifiers">
+            <summary>
+            Whether or not the victim is doing something other than standing when hit. More details on this found at: http://kuroganehammer.com/Smash4/Formulas.  
+            </summary>
+        </member>
+        <member name="P:KuroganeHammer.Data.Api.Models.CalculatorMoveModel.HitboxOption">
+            <summary>
+            The specific hitbox frames for this moves.  Since some moves have multiple frames with multiple hitboxes, specify which hitbox data should be 
+            used.  
             </summary>
         </member>
     </members>

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CalculatorController.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CalculatorController.cs
@@ -78,10 +78,45 @@ namespace KuroganeHammer.Data.Api.Controllers
                 VictimPercent = model.VictimDamagePercent
             });
 
+            var ownerId = Db.Moves.First(m => m.Id == model.MoveId).OwnerId;
             var calcResult = new CompletedCalculationResponseDto
             {
+                CalculatedValueName = "VsModeKnockback",
+                CharacterName = Db.Characters.First(c => c.Id == ownerId).Name,
                 MoveName = Db.Moves.Find(model.MoveId).Name,
                 CalculatedValue = result
+            };
+
+            return Ok(calcResult);
+        }
+
+        [Route(CalculatorRoutePrefix + "/moves/shieldstunnormal")]
+        [Authorize(Roles = Basic)]
+        [HttpPost]
+        public IHttpActionResult PostMoveShieldStunNormal(CalculatorMoveModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var calculator = new Calculator();
+            var move = Db.Moves.Find(model.MoveId);
+
+            if (move == null)
+            {
+                return BadRequest($"Unable to find move with id: {model.MoveId}");
+            }
+
+            var damageAsDouble = Convert.ToDouble(move.BaseDamage);
+            var result = calculator.ShieldStunNormal(damageAsDouble);
+
+            var calcResult = new CompletedCalculationResponseDto
+            {
+                CalculatedValueName = "ShieldStunNormal",
+                CalculatedValue = result,
+                CharacterName = Db.Characters.Find(move.OwnerId).Name,
+                MoveName = move.Name
             };
 
             return Ok(calcResult);

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CalculatorController.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CalculatorController.cs
@@ -1,0 +1,39 @@
+﻿using System.Web.Http;
+using KuroganeHammer.Data.Api.Models;
+using KuroganeHammer.Data.Core.Calculations;
+
+
+namespace KuroganeHammer.Data.Api.Controllers
+{
+    [RoutePrefix("api")]
+    public class CalculatorController : BaseApiController
+    {
+        public CalculatorController()
+        { }
+
+        public CalculatorController(ApplicationDbContext context)
+            : base(context)
+        { }
+
+
+        [Route("calculator")]
+        public IHttpActionResult PostCalculatorRequest(CalculatorRequestModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var calculator = new Calculator();
+            var calcResponseModel = new CalculatorResponseModel
+            {
+                TrainingModeKnockback =
+                    calculator.TrainingModeKnockback(model.VictimPercent, model.BaseDamage, model.TargetWeight,
+                        model.KnockbackGrowth, model.BaseKnockbackSetKnockback,
+                        model.Modifiers.GetModifierValue())
+            };
+
+            return Ok(calcResponseModel);
+        }
+    }
+}

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CalculatorController.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CalculatorController.cs
@@ -4,6 +4,7 @@ using KuroganeHammer.Data.Api.Models;
 using KuroganeHammer.Data.Core.Calculations;
 using static KuroganeHammer.Data.Api.Models.RolesConstants;
 using System.Linq;
+using KuroganeHammer.Data.Api.DTOs;
 using KuroganeHammer.Data.Core;
 
 namespace KuroganeHammer.Data.Api.Controllers
@@ -77,7 +78,13 @@ namespace KuroganeHammer.Data.Api.Controllers
                 VictimPercent = model.VictimDamagePercent
             });
 
-            return Ok(result);
+            var calcResult = new CompletedCalculationResponseDto
+            {
+                MoveName = Db.Moves.Find(model.MoveId).Name,
+                CalculatedValue = result
+            };
+
+            return Ok(calcResult);
         }
 
 

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CalculatorController.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CalculatorController.cs
@@ -9,23 +9,36 @@ using KuroganeHammer.Data.Core;
 
 namespace KuroganeHammer.Data.Api.Controllers
 {
+    /// <summary>
+    /// Controller used for calculating data off of character attributes and properties such as moves.
+    /// </summary>
     [RoutePrefix("api")]
     public class CalculatorController : BaseApiController
     {
         private const string CalculatorRoutePrefix = "calculator";
 
+        /// <summary>
+        /// Creates a <see cref="CalculatorController"/> with the default <see cref="ApplicationDbContext"/>.
+        /// </summary>
         public CalculatorController()
         { }
 
+        /// <summary>
+        /// Creates a <see cref="CalculatorController"/> with the specified <see cref="ApplicationDbContext"/>.
+        /// </summary>
+        /// <param name="context"></param>
         public CalculatorController(ApplicationDbContext context)
             : base(context)
         { }
 
-
+        /// <summary>
+        /// Calculate Rage based on passed in data.
+        /// </summary>
+        /// <param name="data"></param>
+        /// <returns></returns>
         [Route(CalculatorRoutePrefix + "/rage")]
-        [Authorize(Roles = Basic)]
-        [HttpGet]
-        public IHttpActionResult GetRage(RageProblemData data)
+        [HttpPost]
+        public IHttpActionResult PostRage(RageProblemData data)
         {
             if (!ModelState.IsValid)
             {
@@ -38,24 +51,28 @@ namespace KuroganeHammer.Data.Api.Controllers
             return Ok(result);
         }
 
-        [Route(CalculatorRoutePrefix + "/moves/rage")]
-        [Authorize(Roles = Basic)]
-        [HttpGet]
-        public IHttpActionResult GetMoveRage(CalculatorMoveModel model)
-        {
-            if (!ModelState.IsValid)
-            {
-                return BadRequest(ModelState);
-            }
+        //[Route(CalculatorRoutePrefix + "/moves/rage")]
+        //[Authorize(Roles = Basic)]
+        //[HttpGet]
+        //public IHttpActionResult GetMoveRage(CalculatorMoveModel model)
+        //{
+        //    if (!ModelState.IsValid)
+        //    {
+        //        return BadRequest(ModelState);
+        //    }
 
-            var calculator = new Calculator();
-            var result = calculator.Rage(new RageProblemData { AttackerPercent = model.AttackerDamagePercent });
+        //    var calculator = new Calculator();
+        //    var result = calculator.Rage(new RageProblemData { AttackerPercent = model.AttackerDamagePercent });
 
-            return Ok(result);
-        }
+        //    return Ok(result);
+        //}
 
+        /// <summary>
+        /// Calculate Vs mode knockback of a specific character's move.
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
         [Route(CalculatorRoutePrefix + "/moves/vsknockback")]
-        [Authorize(Roles = Basic)]
         [HttpPost]
         public IHttpActionResult PostMoveVsKnockback(CalculatorMoveModel model)
         {
@@ -90,8 +107,12 @@ namespace KuroganeHammer.Data.Api.Controllers
             return Ok(calcResult);
         }
 
+        /// <summary>
+        /// Calculate the Normal Shield stun of a specific character's move.
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
         [Route(CalculatorRoutePrefix + "/moves/shieldstunnormal")]
-        [Authorize(Roles = Basic)]
         [HttpPost]
         public IHttpActionResult PostMoveShieldStunNormal(CalculatorMoveModel model)
         {

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CalculatorController.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CalculatorController.cs
@@ -1,13 +1,18 @@
-﻿using System.Web.Http;
+﻿using System;
+using System.Web.Http;
 using KuroganeHammer.Data.Api.Models;
 using KuroganeHammer.Data.Core.Calculations;
-
+using static KuroganeHammer.Data.Api.Models.RolesConstants;
+using System.Linq;
+using KuroganeHammer.Data.Core;
 
 namespace KuroganeHammer.Data.Api.Controllers
 {
     [RoutePrefix("api")]
     public class CalculatorController : BaseApiController
     {
+        private const string CalculatorRoutePrefix = "calculator";
+
         public CalculatorController()
         { }
 
@@ -16,8 +21,10 @@ namespace KuroganeHammer.Data.Api.Controllers
         { }
 
 
-        [Route("calculator")]
-        public IHttpActionResult PostCalculatorRequest(CalculatorRequestModel model)
+        [Route(CalculatorRoutePrefix + "/rage")]
+        [Authorize(Roles = Basic)]
+        [HttpGet]
+        public IHttpActionResult GetRage(RageProblemData data)
         {
             if (!ModelState.IsValid)
             {
@@ -25,15 +32,89 @@ namespace KuroganeHammer.Data.Api.Controllers
             }
 
             var calculator = new Calculator();
-            var calcResponseModel = new CalculatorResponseModel
-            {
-                TrainingModeKnockback =
-                    calculator.TrainingModeKnockback(model.VictimPercent, model.BaseDamage, model.TargetWeight,
-                        model.KnockbackGrowth, model.BaseKnockbackSetKnockback,
-                        model.Modifiers.GetModifierValue())
-            };
+            var result = calculator.Rage(data);
 
-            return Ok(calcResponseModel);
+            return Ok(result);
         }
+
+        [Route(CalculatorRoutePrefix + "/moves/rage")]
+        [Authorize(Roles = Basic)]
+        [HttpGet]
+        public IHttpActionResult GetMoveRage(CalculatorMoveModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var calculator = new Calculator();
+            var result = calculator.Rage(new RageProblemData { AttackerPercent = model.AttackerDamagePercent });
+
+            return Ok(result);
+        }
+
+        [Route(CalculatorRoutePrefix + "/moves/vsknockback")]
+        [Authorize(Roles = Basic)]
+        [HttpPost]
+        public IHttpActionResult PostMoveVsKnockback(CalculatorMoveModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var calculator = new Calculator();
+            var result = calculator.VersusModeKnockback(new VersusModeKnockbackProblemData
+            {
+                BaseDamage = Convert.ToDouble(GetHitboxValue(Db.BaseDamage.Single(b => b.MoveId == model.MoveId), model.HitboxOption)),
+                AttackerPercent = model.AttackerDamagePercent,
+                BaseKnockbackSetKnockback =
+                    Convert.ToInt32(GetHitboxValue(Db.BaseKnockbackSetKnockback.Single(b => b.MoveId == model.MoveId), model.HitboxOption)),
+                KnockbackGrowth = Convert.ToInt32(GetHitboxValue(Db.KnockbackGrowth.Single(k => k.MoveId == model.MoveId), model.HitboxOption)),
+                StaleMoveMultiplier = model.StaleMoveNegationMultiplier.GetModifierValue(),
+                StanceModifier = model.Modifiers.GetModifierValue(),
+                TargetWeight = model.TargetWeight,
+                VictimPercent = model.VictimDamagePercent
+            });
+
+            return Ok(result);
+        }
+
+
+        private string GetHitboxValue(BaseMoveHitboxMeta hitboxModel, HitboxOptions hitboxOption)
+        {
+            Guard.VerifyObjectNotNull(hitboxModel, nameof(hitboxModel));
+            Guard.VerifyObjectNotNull(hitboxOption, nameof(hitboxOption));
+
+            switch (hitboxOption)
+            {
+                case HitboxOptions.First:
+                    {
+                        return hitboxModel.Hitbox1;
+                    }
+                case HitboxOptions.Second:
+                    {
+                        return hitboxModel.Hitbox2;
+                    }
+
+                case HitboxOptions.Third:
+                    {
+                        return hitboxModel.Hitbox3;
+                    }
+                case HitboxOptions.Fourth:
+                    {
+                        return hitboxModel.Hitbox4;
+                    }
+                case HitboxOptions.Fifth:
+                    {
+                        return hitboxModel.Hitbox5;
+                    }
+                default:
+                    {
+                        throw new Exception($"{hitboxOption} not recognized.");
+                    }
+            }
+        }
+
     }
 }

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CharacterAttributeTypesController.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CharacterAttributeTypesController.cs
@@ -35,7 +35,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// Get all of the <see cref="CharacterAttributeType"/> details.
         /// </summary>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [Route("characterattributetypes")]
         public IQueryable<CharacterAttributeType> GetCharacterAttributeTypes()
         {
@@ -47,7 +46,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [ResponseType(typeof(CharacterAttributeType))]
         [Route("characterattributetypes/{id}")]
         public IHttpActionResult GetCharacterAttributeType(int id)

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CharacterAttributesController.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CharacterAttributesController.cs
@@ -35,7 +35,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// Get all <see cref="CharacterAttribute"/>s.
         /// </summary>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [Route("characterattributes")]
         public IQueryable<CharacterAttribute> GetCharacterAttributes()
         {
@@ -47,7 +46,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [ResponseType(typeof(CharacterAttribute))]
         [Route("characterattributes/{id}")]
         public IHttpActionResult GetCharacterAttribute(int id)

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CharactersController.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/CharactersController.cs
@@ -37,7 +37,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// Get all of the <see cref="Character"/> details.
         /// </summary>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [Route("characters")]
         public IQueryable<Character> GetCharacters()
         {
@@ -49,7 +48,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [ResponseType(typeof(Character))]
         [Route("characters/{id}")]
         public IHttpActionResult GetCharacter(int id)
@@ -68,7 +66,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [Route("Characters/{id}/movements")]
         [HttpGet]
         public IQueryable<MovementDto> GetMovementsForCharacter(int id)
@@ -84,7 +81,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [Route("Characters/{id}/moves")]
         public IQueryable<MoveDto> GetMovesForCharacter(int id)
         {

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/MovementsController.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/MovementsController.cs
@@ -28,7 +28,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// <summary>
         /// Get all movement data.
         /// </summary>
-        [Authorize(Roles = Basic)]
         [ResponseType(typeof(IQueryable<MovementDto>))]
         [Route("movements", Name = "GetAllMovements")]
         public IQueryable<MovementDto> GetMovements()
@@ -44,7 +43,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [ResponseType(typeof(IQueryable<MovementDto>))]
         [Route("movements/byname", Name = "GetMovementsByName")]
         public IQueryable<MovementDto> GetMovementsByName([FromUri] string name)
@@ -60,7 +58,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [ResponseType(typeof(MovementDto))]
         [Route("movements/{id}")]
         public IHttpActionResult GetMovement(int id)

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/MovesController.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/MovesController.cs
@@ -29,7 +29,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// Get all moves.  Not sure if this is sticking around.
         /// </summary>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [ResponseType(typeof(IQueryable<MoveDto>))]
         [Route("moves")]
         public IQueryable<MoveDto> GetMoves()
@@ -45,7 +44,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [ResponseType(typeof(IQueryable<MoveDto>))]
         [Route("moves/byname")]
         public IQueryable<MoveDto> GetMovesByName([FromUri] string name)
@@ -61,7 +59,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [ResponseType(typeof(MoveDto))]
         [Route("moves/{id}")]
         public IHttpActionResult GetMove(int id)
@@ -84,7 +81,7 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// <param name="move"></param>
         /// <returns></returns>
         [Authorize(Roles = Admin)]
-        [ResponseType(typeof(void))]
+        [ResponseType(typeof(IHttpActionResult))]
         [Route("moves/{id}")]
         public IHttpActionResult PutMove(int id, Move move)
         {

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/NotationsController.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/NotationsController.cs
@@ -34,7 +34,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// Get all <see cref="Notation"/>s.
         /// </summary>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [Route("notations")]
         public IQueryable<Notation> GetNotations()
         {
@@ -46,7 +45,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [ResponseType(typeof(Notation))]
         [Route("notations/{id}")]
         public IHttpActionResult GetNotation(int id)
@@ -66,7 +64,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// <param name="id"></param>
         /// <param name="notation"></param>
         /// <returns></returns>
-        [Authorize(Roles = Admin)]
         [ResponseType(typeof(void))]
         [Route("notations/{id}")]
         public IHttpActionResult PutNotation(int id, Notation notation)

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/SmashAttributeTypesController.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Controllers/SmashAttributeTypesController.cs
@@ -32,7 +32,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// Get all of the stored <see cref="SmashAttributeType"/>s.
         /// </summary>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [ResponseType(typeof(IQueryable<SmashAttributeType>))]
         [Route("smashattributetypes")]
         public IQueryable<SmashAttributeType> GetSmashAttributeTypes()
@@ -45,7 +44,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [ResponseType(typeof(SmashAttributeType))]
         [Route("smashattributetypes/{id}")]
         public IHttpActionResult GetSmashAttributeType(int id)
@@ -67,7 +65,6 @@ namespace KuroganeHammer.Data.Api.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        [Authorize(Roles = Basic)]
         [Route("smashattributetypes/{id}/characterattributes")]
         public IHttpActionResult GetAllCharacterAttributeOfSmashAttributeType(int id)
         {

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/DTOs/CalculatorDtos.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/DTOs/CalculatorDtos.cs
@@ -1,0 +1,8 @@
+﻿namespace KuroganeHammer.Data.Api.DTOs
+{
+    public class CompletedCalculationResponseDto
+    {
+        public string MoveName { get; set; }
+        public double CalculatedValue { get; set; }
+    }
+}

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/DTOs/CalculatorDtos.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/DTOs/CalculatorDtos.cs
@@ -2,6 +2,8 @@
 {
     public class CompletedCalculationResponseDto
     {
+        public string CalculatedValueName { get; set;}
+        public string CharacterName { get; set; }
         public string MoveName { get; set; }
         public double CalculatedValue { get; set; }
     }

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/KuroganeHammer.Data.Api.csproj
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/KuroganeHammer.Data.Api.csproj
@@ -242,6 +242,7 @@
     <Compile Include="App_Start\WebApiConfig.cs" />
     <Compile Include="Controllers\AccountController.cs" />
     <Compile Include="Controllers\BaseApiController.cs" />
+    <Compile Include="Controllers\CalculatorController.cs" />
     <Compile Include="Controllers\CharacterAttributesController.cs" />
     <Compile Include="Controllers\CharacterAttributeTypesController.cs" />
     <Compile Include="Controllers\CharactersController.cs" />
@@ -326,6 +327,7 @@
     <Compile Include="Migrations\Configuration.cs" />
     <Compile Include="Models\AccountBindingModels.cs" />
     <Compile Include="Models\AccountViewModels.cs" />
+    <Compile Include="Models\CalculatorModels.cs" />
     <Compile Include="Models\CharacterAttributeModels.cs" />
     <Compile Include="Models\Character.cs" />
     <Compile Include="Models\CharacterAttributeType.cs" />

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/KuroganeHammer.Data.Api.csproj
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/KuroganeHammer.Data.Api.csproj
@@ -251,6 +251,7 @@
     <Compile Include="Controllers\NotationsController.cs" />
     <Compile Include="Controllers\RolesController.cs" />
     <Compile Include="Controllers\SmashAttributeTypesController.cs" />
+    <Compile Include="DTOs\CalculatorDtos.cs" />
     <Compile Include="DTOs\CharacterAttributeDto.cs" />
     <Compile Include="DTOs\CharacterAttributeRowDto.cs" />
     <Compile Include="DTOs\MoveDto.cs" />

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Models/CalculatorModels.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Models/CalculatorModels.cs
@@ -16,7 +16,7 @@ namespace KuroganeHammer.Data.Api.Models
         public double Staleness { get; set; }
         public Modifiers Modifiers { get; set; }
         public ElectricModifier ElectricModifier { get; set; }
-        public HitlagModifierType HitlagModifierType { get; set; }
+        public CrouchingModifier CrouchingModifier { get; set; }
         public ShieldAdvantageModifier ShieldAdvantageModifier { get; set; }
     }
 

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Models/CalculatorModels.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Models/CalculatorModels.cs
@@ -39,4 +39,18 @@ namespace KuroganeHammer.Data.Api.Models
         public int ShieldStun_PowershieldProjectile { get; set; }
     }
 
+    public class CalculatorMoveModel
+    {
+        public int MoveId { get; set; }
+        public int AttackerDamagePercent { get; set; }
+        public int VictimDamagePercent { get; set; }
+        public int TargetWeight { get; set; }
+        public StaleMoveNegationMultipler StaleMoveNegationMultiplier { get; set; } = StaleMoveNegationMultipler.S1;
+        public ElectricModifier ElectricModifier { get; set; } = ElectricModifier.NormalAttack;
+        public CrouchingModifier CrouchingModifier { get; set; } = CrouchingModifier.NotCrouching;
+        public ShieldAdvantageModifier ShieldAdvantageModifier { get; set; } = ShieldAdvantageModifier.Regular;
+        public Modifiers Modifiers { get; set; } = Modifiers.Standing;
+        public HitboxOptions HitboxOption { get; set; } = HitboxOptions.First;
+    }
+
 }

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Models/CalculatorModels.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Models/CalculatorModels.cs
@@ -2,54 +2,101 @@
 
 namespace KuroganeHammer.Data.Api.Models
 {
-    public class CalculatorRequestModel
-    {
-        public double AttackerPercent { get; set; }
-        public double VictimPercent { get; set; }
-        public int BaseDamage { get; set; }
-        public double TargetWeight { get; set; }
-        public double KnockbackGrowth { get; set; }
-        public int BaseKnockbackSetKnockback { get; set; }
-        public double HitlagModifier { get; set; }
-        public int HitFrame { get; set; }
-        public int FirstActiveFrame { get; set; }
-        public double Staleness { get; set; }
-        public Modifiers Modifiers { get; set; }
-        public ElectricModifier ElectricModifier { get; set; }
-        public CrouchingModifier CrouchingModifier { get; set; }
-        public ShieldAdvantageModifier ShieldAdvantageModifier { get; set; }
-    }
+    ///// <summary>
+    ///// Base model for making
+    ///// </summary>
+    //public class CalculatorRequestModel
+    //{
+    //    public double AttackerPercent { get; set; }
+    //    public double VictimPercent { get; set; }
+    //    public int BaseDamage { get; set; }
+    //    public double TargetWeight { get; set; }
+    //    public double KnockbackGrowth { get; set; }
+    //    public int BaseKnockbackSetKnockback { get; set; }
+    //    public double HitlagModifier { get; set; }
+    //    public int HitFrame { get; set; }
+    //    public int FirstActiveFrame { get; set; }
+    //    public double Staleness { get; set; }
+    //    public Modifiers Modifiers { get; set; }
+    //    public ElectricModifier ElectricModifier { get; set; }
+    //    public CrouchingModifier CrouchingModifier { get; set; }
+    //    public ShieldAdvantageModifier ShieldAdvantageModifier { get; set; }
+    //}
 
-    
 
-    public class CalculatorResponseModel
-    {
-        public double Rage { get; set; }
-        public double TrainingModeKnockback { get; set; }
-        public double VersusModeKnockback { get; set; }
-        public int HitstunFrames { get; set; }
-        public int HitlagFrames { get; set; }
-        public int ShieldAdvantage_Normal { get; set; }
-        public int ShieldAdvantage_Powershield { get; set; }
-        public int ShieldAdvantage_Projectile { get; set; }
-        public int ShieldAdvantage_PowershieldProjectile { get; set; }
-        public int ShieldStun_Normal { get; set; }
-        public int ShieldStun_Powershield { get; set; }
-        public int ShieldStun_Projectile { get; set; }
-        public int ShieldStun_PowershieldProjectile { get; set; }
-    }
 
+    //public class CalculatorResponseModel
+    //{
+    //    public double Rage { get; set; }
+    //    public double TrainingModeKnockback { get; set; }
+    //    public double VersusModeKnockback { get; set; }
+    //    public int HitstunFrames { get; set; }
+    //    public int HitlagFrames { get; set; }
+    //    public int ShieldAdvantage_Normal { get; set; }
+    //    public int ShieldAdvantage_Powershield { get; set; }
+    //    public int ShieldAdvantage_Projectile { get; set; }
+    //    public int ShieldAdvantage_PowershieldProjectile { get; set; }
+    //    public int ShieldStun_Normal { get; set; }
+    //    public int ShieldStun_Powershield { get; set; }
+    //    public int ShieldStun_Projectile { get; set; }
+    //    public int ShieldStun_PowershieldProjectile { get; set; }
+    //}
+
+    /// <summary>
+    /// Model used for performing calculations on character moves.
+    /// </summary>
     public class CalculatorMoveModel
     {
+        /// <summary>
+        /// The Id of the Move in question.
+        /// </summary>
         public int MoveId { get; set; }
+
+        /// <summary>
+        /// The damage percent the attacker has.
+        /// </summary>
         public int AttackerDamagePercent { get; set; }
+
+        /// <summary>
+        /// The damage percent the target being hit has.
+        /// </summary>
         public int VictimDamagePercent { get; set; }
+
+        /// <summary>
+        /// The weight of the target.
+        /// </summary>
         public int TargetWeight { get; set; }
+
+        /// <summary>
+        /// The stale move negation level.  More details on this found at: http://kuroganehammer.com/Smash4/Formulas.  
+        /// Default in no staleness on a move.
+        /// </summary>
         public StaleMoveNegationMultipler StaleMoveNegationMultiplier { get; set; } = StaleMoveNegationMultipler.S1;
+
+        /// <summary>
+        /// What type of attack is being performed.  More details on this found at: http://kuroganehammer.com/Smash4/Formulas.   
+        /// </summary>
         public ElectricModifier ElectricModifier { get; set; } = ElectricModifier.NormalAttack;
+
+        /// <summary>
+        /// Whether or not the target being hit is crouching or otherwise.  More details on this found at: http://kuroganehammer.com/Smash4/Formulas.  
+        /// </summary>
         public CrouchingModifier CrouchingModifier { get; set; } = CrouchingModifier.NotCrouching;
+
+        /// <summary>
+        /// Shield advantage modifier based on normal or projectile.  More details on this found at: http://kuroganehammer.com/Smash4/Formulas.  
+        /// </summary>
         public ShieldAdvantageModifier ShieldAdvantageModifier { get; set; } = ShieldAdvantageModifier.Regular;
+
+        /// <summary>
+        /// Whether or not the victim is doing something other than standing when hit. More details on this found at: http://kuroganehammer.com/Smash4/Formulas.  
+        /// </summary>
         public Modifiers Modifiers { get; set; } = Modifiers.Standing;
+
+        /// <summary>
+        /// The specific hitbox frames for this moves.  Since some moves have multiple frames with multiple hitboxes, specify which hitbox data should be 
+        /// used.  
+        /// </summary>
         public HitboxOptions HitboxOption { get; set; } = HitboxOptions.First;
     }
 

--- a/KuroganeHammer.Data/KuroganeHammer.Data.Api/Models/CalculatorModels.cs
+++ b/KuroganeHammer.Data/KuroganeHammer.Data.Api/Models/CalculatorModels.cs
@@ -1,0 +1,42 @@
+﻿using KuroganeHammer.Data.Core.Calculations;
+
+namespace KuroganeHammer.Data.Api.Models
+{
+    public class CalculatorRequestModel
+    {
+        public double AttackerPercent { get; set; }
+        public double VictimPercent { get; set; }
+        public int BaseDamage { get; set; }
+        public double TargetWeight { get; set; }
+        public double KnockbackGrowth { get; set; }
+        public int BaseKnockbackSetKnockback { get; set; }
+        public double HitlagModifier { get; set; }
+        public int HitFrame { get; set; }
+        public int FirstActiveFrame { get; set; }
+        public double Staleness { get; set; }
+        public Modifiers Modifiers { get; set; }
+        public ElectricModifier ElectricModifier { get; set; }
+        public HitlagModifierType HitlagModifierType { get; set; }
+        public ShieldAdvantageModifier ShieldAdvantageModifier { get; set; }
+    }
+
+    
+
+    public class CalculatorResponseModel
+    {
+        public double Rage { get; set; }
+        public double TrainingModeKnockback { get; set; }
+        public double VersusModeKnockback { get; set; }
+        public int HitstunFrames { get; set; }
+        public int HitlagFrames { get; set; }
+        public int ShieldAdvantage_Normal { get; set; }
+        public int ShieldAdvantage_Powershield { get; set; }
+        public int ShieldAdvantage_Projectile { get; set; }
+        public int ShieldAdvantage_PowershieldProjectile { get; set; }
+        public int ShieldStun_Normal { get; set; }
+        public int ShieldStun_Powershield { get; set; }
+        public int ShieldStun_Projectile { get; set; }
+        public int ShieldStun_PowershieldProjectile { get; set; }
+    }
+
+}


### PR DESCRIPTION
- Introduced support to mimic what the existing calculator app accomplishes.
- Support to send in a character's move and get calculator data back from it (this may be stored in the db in the future)
- CalculatorController created
- Publicized and documented the Data.Core project.  This is people can see how to build up these calculator models as well as the models for page scraping.  NOTE: Did not complete documentation on the actual WebScraper project for now.
