### PR TITLE
- Added initial support for server-side caching via CacheCow.

### DIFF
--- a/FrannHammer.AccountRegistration/App.config
+++ b/FrannHammer.AccountRegistration/App.config
@@ -15,7 +15,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Cors" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/FrannHammer.AccountRegistrationTool.Tests/app.config
+++ b/FrannHammer.AccountRegistrationTool.Tests/app.config
@@ -12,7 +12,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/FrannHammer.Api/App_Start/WebApiConfig.cs
+++ b/FrannHammer.Api/App_Start/WebApiConfig.cs
@@ -5,6 +5,8 @@ using System.Net.Http.Formatting;
 using System.Net.Http.Headers;
 using System.Web.Http;
 using Autofac.Integration.WebApi;
+using CacheCow.Server;
+using CacheCow.Server.EntityTagStore.SqlServer;
 using Microsoft.Owin.Security.OAuth;
 using Newtonsoft.Json.Serialization;
 using Swashbuckle.Application;
@@ -47,7 +49,22 @@ namespace FrannHammer.Api
                 },
                 Repository = new CacheRepository()
             });
+
+            //cache on db in release mode
+            var connectionString = ConfigurationManager.ConnectionStrings["DefaultConnection"].ConnectionString;
+            var eTagStore = new SqlServerEntityTagStore(connectionString);
+
+            var cacheCowCacheHandler = new CachingHandler(config, eTagStore)
+            {
+                AddLastModifiedHeader = false
+            };
+            config.MessageHandlers.Add(cacheCowCacheHandler);
+
+#else
+            //in memory caching for debug mode
+            config.MessageHandlers.Add(new CachingHandler(config));
 #endif
+
 
             config.EnableSwagger(c =>
             {

--- a/FrannHammer.Api/FrannHammer.Api.csproj
+++ b/FrannHammer.Api/FrannHammer.Api.csproj
@@ -56,6 +56,18 @@
       <HintPath>..\packages\AutoMapper.5.0.2\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="CacheCow.Common, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CacheCow.Common.1.2.0\lib\net40\CacheCow.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="CacheCow.Server, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CacheCow.Server.1.2.0\lib\net40\CacheCow.Server.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="CacheCow.Server.EntityTagStore.SqlServer, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CacheCow.Server.EntityTagStore.SqlServer.1.0.0\lib\net40\CacheCow.Server.EntityTagStore.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin.Cors, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.Cors.3.0.1\lib\net45\Microsoft.Owin.Cors.dll</HintPath>

--- a/FrannHammer.Api/Startup.cs
+++ b/FrannHammer.Api/Startup.cs
@@ -3,7 +3,6 @@ using System.Web.Mvc;
 using AutoMapper;
 using FrannHammer.Api;
 using FrannHammer.Models;
-using FrannHammer.Models.DTOs;
 using Microsoft.Owin;
 using Microsoft.Owin.Cors;
 using Owin;

--- a/FrannHammer.Api/Web.config
+++ b/FrannHammer.Api/Web.config
@@ -21,7 +21,7 @@
       </system.Web>
   -->
   <system.web>
-    <compilation targetFramework="4.5"/>
+    <compilation targetFramework="4.5" />
     <httpRuntime targetFramework="4.5" />
   </system.web>
   <system.webServer>

--- a/FrannHammer.Api/packages.config
+++ b/FrannHammer.Api/packages.config
@@ -4,6 +4,9 @@
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
   <package id="Autofac.WebApi2" version="3.4.0" targetFramework="net45" />
   <package id="AutoMapper" version="5.0.2" targetFramework="net45" />
+  <package id="CacheCow.Common" version="1.2.0" targetFramework="net45" />
+  <package id="CacheCow.Server" version="1.2.0" targetFramework="net45" />
+  <package id="CacheCow.Server.EntityTagStore.SqlServer" version="1.0.0" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="jQuery" version="3.1.0" targetFramework="net45" />
   <package id="jQuery.Validation" version="1.15.0" targetFramework="net45" />

--- a/FrannHammer.Services.Tests/App.config
+++ b/FrannHammer.Services.Tests/App.config
@@ -10,4 +10,40 @@
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Cors" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>


### PR DESCRIPTION
- This will generate an eTag based on response that client can store and verify via If-None-Match header when sending a request.
