### PR TITLE
Added support for Redis to Move Search functionality

### DIFF
--- a/FrannHammer.Api/App_Data/XmlDocument.xml
+++ b/FrannHammer.Api/App_Data/XmlDocument.xml
@@ -612,7 +612,7 @@
             Handles server operations dealing with <see cref="T:FrannHammer.Models.Move"/>s.
             </summary>
         </member>
-        <member name="M:FrannHammer.Api.Controllers.MovesController.#ctor(FrannHammer.Services.IMetadataService)">
+        <member name="M:FrannHammer.Api.Controllers.MovesController.#ctor(FrannHammer.Services.IMetadataService,StackExchange.Redis.IConnectionMultiplexer)">
             <summary>
             Create a new <see cref="T:FrannHammer.Api.Controllers.MovesController"/>.
             </summary>

--- a/FrannHammer.Api/App_Start/WebApiConfig.cs
+++ b/FrannHammer.Api/App_Start/WebApiConfig.cs
@@ -9,6 +9,7 @@ using CacheCow.Server;
 using CacheCow.Server.EntityTagStore.SqlServer;
 using Microsoft.Owin.Security.OAuth;
 using Newtonsoft.Json.Serialization;
+using StackExchange.Redis;
 using Swashbuckle.Application;
 using WebApiThrottle;
 
@@ -19,6 +20,13 @@ namespace FrannHammer.Api
         #region custom config keys
         private const string KeyThrottleRequestsPerSecond = "throttlingrequestspersecond";
         #endregion
+
+        public static IConnectionMultiplexer RedisMultiplexer;
+
+        static WebApiConfig()
+        {
+            RedisMultiplexer = ConnectionMultiplexer.Connect("localhost");
+        }
 
         public static void Register(HttpConfiguration config)
         {
@@ -37,6 +45,7 @@ namespace FrannHammer.Api
             );
 
             config.DependencyResolver = new AutofacWebApiDependencyResolver(Container.Instance.AutoFacContainer);
+
 
 #if !DEBUG
             int throttleRequestsPerSecond = GetConfigValue<int>(KeyThrottleRequestsPerSecond);

--- a/FrannHammer.Api/Container.cs
+++ b/FrannHammer.Api/Container.cs
@@ -62,7 +62,8 @@ namespace FrannHammer.Api
 
             builder.RegisterType<MovesController>()
                 .As<MovesController>()
-                .WithParameter(metadataServiceName, metadataService);
+                .WithParameter(metadataServiceName, metadataService)
+                .WithParameter("redisConnectionMultiplexer", WebApiConfig.RedisMultiplexer);
 
             builder.RegisterType<NotationsController>()
                 .As<NotationsController>()

--- a/FrannHammer.Api/Controllers/MovesController.cs
+++ b/FrannHammer.Api/Controllers/MovesController.cs
@@ -7,6 +7,7 @@ using FrannHammer.Api.ActionFilterAttributes;
 using FrannHammer.Api.Models;
 using FrannHammer.Models;
 using FrannHammer.Services;
+using StackExchange.Redis;
 
 namespace FrannHammer.Api.Controllers
 {
@@ -18,13 +19,15 @@ namespace FrannHammer.Api.Controllers
     {
         private const string MovesRouteKey = "moves";
         private readonly IMetadataService _metadataService;
+        private readonly IConnectionMultiplexer _redisConnectionMultiplexer;
 
         /// <summary>
         /// Create a new <see cref="MovesController"/>.
         /// </summary>
-        public MovesController(IMetadataService metadataService)
+        public MovesController(IMetadataService metadataService, IConnectionMultiplexer redisConnectionMultiplexer)
         {
             _metadataService = metadataService;
+            _redisConnectionMultiplexer = redisConnectionMultiplexer;
         }
 
         //Too big to be useful?
@@ -47,9 +50,9 @@ namespace FrannHammer.Api.Controllers
         [ValidateModel]
         [Route(MovesRouteKey + "/search")]
         [HttpPost]
-        public IHttpActionResult GetMovesThatMeetCriteria(ComplexMoveSearchModel complexMoveSearchModel, [FromUri] string fields = "")
+        public IHttpActionResult GetMovesThatMeetCriteria(MoveSearchModel moveSearchModel, [FromUri] string fields = "")
         {
-            var content = _metadataService.GetAll<MoveDto>(complexMoveSearchModel, fields);
+            var content = _metadataService.GetAll<MoveDto>(moveSearchModel, _redisConnectionMultiplexer, fields);
             return Ok(content);
         }
 

--- a/FrannHammer.Api/FrannHammer.Api.csproj
+++ b/FrannHammer.Api/FrannHammer.Api.csproj
@@ -118,6 +118,10 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="StackExchange.Redis, Version=1.1.608.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.1.608\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Swashbuckle.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cd1bb07a5ac7c7bc, processorArchitecture=MSIL">
       <HintPath>..\packages\Swashbuckle.Core.5.4.0\lib\net40\Swashbuckle.Core.dll</HintPath>
       <Private>True</Private>
@@ -125,6 +129,7 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
@@ -327,9 +332,6 @@
       <Project>{7e5c008b-ae84-4d50-bc4b-9d49d8d53870}</Project>
       <Name>FrannHammer.Services</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <WCFMetadata Include="Service References\" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/FrannHammer.Api/Startup.cs
+++ b/FrannHammer.Api/Startup.cs
@@ -23,6 +23,7 @@ namespace FrannHammer.Api
             ConfigureAuth(app, Container.Instance.AutoFacContainer);
 
             ConfigureAutoMapping();
+
         }
 
         internal static void ConfigureAutoMapping()

--- a/FrannHammer.Api/Web.config
+++ b/FrannHammer.Api/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=301879
@@ -6,11 +6,11 @@
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
-  <connectionStrings configSource="ConnectionStrings.config"/>
+  <connectionStrings configSource="ConnectionStrings.config" />
   <appSettings file="..\appsettings.config">
-    <add key="throttlingrequestspersecond" value="100"/>
+    <add key="throttlingrequestspersecond" value="100" />
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -21,95 +21,95 @@
       </system.Web>
   -->
   <system.web>
-    <compilation targetFramework="4.5" debug="true"/>
-    <httpRuntime targetFramework="4.5"/>
+    <compilation targetFramework="4.5" debug="true" />
+    <httpRuntime targetFramework="4.5" />
     <httpModules>
-      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web"/>
+      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" />
     </httpModules>
   </system.web>
   <system.webServer>
     <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
-      <remove name="OPTIONSVerbHandler"/>
-      <remove name="TRACEVerbHandler"/>
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" resourceType="Unspecified" requireAccess="Script" preCondition="integratedMode,runtimeVersionv4.0"/>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" resourceType="Unspecified" requireAccess="Script" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
-    <validation validateIntegratedModeConfiguration="false"/>
+    <validation validateIntegratedModeConfiguration="false" />
     <modules runAllManagedModulesForAllRequests="true">
-      <remove name="ApplicationInsightsWebTracking"/>
-      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler"/>
+      <remove name="ApplicationInsightsWebTracking" />
+      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
     </modules>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0"/>
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0"/>
+        <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0"/>
+        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0"/>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
+        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Cors" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+        <assemblyIdentity name="System.Web.Cors" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
+        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework"/>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
 </configuration>

--- a/FrannHammer.Api/packages.config
+++ b/FrannHammer.Api/packages.config
@@ -48,8 +48,10 @@
   <package id="Modernizr" version="2.8.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net452" />
+  <package id="redis-64" version="3.0.503" targetFramework="net45" />
   <package id="Respond" version="1.4.2" targetFramework="net45" />
   <package id="secure-file" version="1.0.31" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.1.608" targetFramework="net45" />
   <package id="Swashbuckle.Core" version="5.4.0" targetFramework="net45" />
   <package id="WebActivatorEx" version="2.1.0" targetFramework="net45" />
   <package id="WebApiThrottle" version="1.4.3" targetFramework="net45" />

--- a/FrannHammer.Models/FrannHammer.Models.csproj
+++ b/FrannHammer.Models/FrannHammer.Models.csproj
@@ -85,7 +85,7 @@
     <Compile Include="Character.cs" />
     <Compile Include="CharacterAttributeModels.cs" />
     <Compile Include="CharacterAttributeType.cs" />
-    <Compile Include="ComplexMoveSearchModel.cs" />
+    <Compile Include="MoveSearchModel.cs" />
     <Compile Include="DTOs\BaseMoveHitboxMetaDto.cs" />
     <Compile Include="DTOs\CalculatorDtos.cs" />
     <Compile Include="DTOs\CharacterAttributeRowDto.cs" />

--- a/FrannHammer.Models/MoveSearchModel.cs
+++ b/FrannHammer.Models/MoveSearchModel.cs
@@ -9,7 +9,7 @@
     /// For example, an <see cref="RangeQuantifier.EqualTo"/> based <see cref="RangeModel"/>
     /// does not need both the Start and End values filled in (just the Start).
     /// </summary>
-    public class ComplexMoveSearchModel
+    public class MoveSearchModel
     {
         public string Name { get; set; }
         public string CharacterName { get; set; }

--- a/FrannHammer.Services.Tests/FrannHammer.Services.Tests.csproj
+++ b/FrannHammer.Services.Tests/FrannHammer.Services.Tests.csproj
@@ -62,6 +62,10 @@
       <HintPath>..\packages\Moq.4.5.21\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NMemory, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6a46696d54971e6d, processorArchitecture=MSIL">
       <HintPath>..\packages\NMemory.1.1.0\lib\net45\NMemory.dll</HintPath>
       <Private>True</Private>
@@ -70,9 +74,14 @@
       <HintPath>..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="StackExchange.Redis, Version=1.1.608.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.1.608\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -94,6 +103,7 @@
     <Compile Include="MoveSearch\HitboxActiveSearchPredicateServiceTest.cs" />
     <Compile Include="MoveSearch\LandingLagSearchPredicateServiceTest.cs" />
     <Compile Include="MoveSearch\MetadataServiceSearchTest.cs" />
+    <Compile Include="MoveSearch\MoveSearchModelRedisServiceTest.cs" />
     <Compile Include="MoveSearch\NameSearchPredicateServiceTest.cs" />
     <Compile Include="MoveSearch\RangeQuantifierServiceTest.cs" />
     <Compile Include="Suts\MoveDataSut.cs" />

--- a/FrannHammer.Services.Tests/Harnesses/MoveSearchHarness.cs
+++ b/FrannHammer.Services.Tests/Harnesses/MoveSearchHarness.cs
@@ -11,7 +11,7 @@ namespace FrannHammer.Services.Tests.Harnesses
     {
         string Fields { get; }
 
-        void SearchResultCollectionIsValid<TMoveType>(ComplexMoveSearchModel searchModel,
+        void SearchResultCollectionIsValid<TMoveType>(MoveSearchModel searchModel,
             IApplicationDbContext context, Func<TMoveType, bool> serviceSearchMethod)
             where TMoveType : class, IMoveIdEntity;
     }
@@ -29,7 +29,7 @@ namespace FrannHammer.Services.Tests.Harnesses
             Fields = fields;
         }
 
-        public void SearchResultCollectionIsValid<TMoveType>(ComplexMoveSearchModel searchModel,
+        public void SearchResultCollectionIsValid<TMoveType>(MoveSearchModel searchModel,
            IApplicationDbContext context, Func<TMoveType, bool> serviceSearchMethod)
            where TMoveType : class, IMoveIdEntity
         {

--- a/FrannHammer.Services.Tests/MetadataServiceTest.cs
+++ b/FrannHammer.Services.Tests/MetadataServiceTest.cs
@@ -3,6 +3,7 @@ using FrannHammer.Models;
 using FrannHammer.Services.Exceptions;
 using FrannHammer.Services.Tests.Harnesses;
 using NUnit.Framework;
+using StackExchange.Redis;
 
 namespace FrannHammer.Services.Tests
 {

--- a/FrannHammer.Services.Tests/MoveSearch/MetadataServiceSearchTest.cs
+++ b/FrannHammer.Services.Tests/MoveSearch/MetadataServiceSearchTest.cs
@@ -33,10 +33,10 @@ namespace FrannHammer.Services.Tests.MoveSearch
             _moveSearchHarness = new MoveSearchHarness(string.Empty);
         }
 
-        private IList<dynamic> AssertSearchResultsAreValid(ComplexMoveSearchModel searchModel, Action<List<dynamic>> countAssertion = null,
+        private IList<dynamic> AssertSearchResultsAreValid(MoveSearchModel searchModel, Action<List<dynamic>> countAssertion = null,
             string fields = "")
         {
-            var results = _metadataService.GetAll<MoveDto>(searchModel).ToList();
+            var results = _metadataService.GetAll<MoveDto>(searchModel, null).ToList();
 
             Assert.That(results, Is.Not.Null);
 
@@ -56,7 +56,7 @@ namespace FrannHammer.Services.Tests.MoveSearch
         [Test]
         public void ReturnsAllMovesForCharacterWhenNoOtherAttributesSpecified()
         {
-            var searchModel = new ComplexMoveSearchModel
+            var searchModel = new MoveSearchModel
             {
                 CharacterName = "Ganondorf"
             };
@@ -69,7 +69,7 @@ namespace FrannHammer.Services.Tests.MoveSearch
         [Test]
         public void ReturnsSingleResultUsingMultipleSearchAttributes()
         {
-            var searchModel = new ComplexMoveSearchModel
+            var searchModel = new MoveSearchModel
             {
                 Angle = new RangeModel { StartValue = 10, RangeQuantifier = RangeQuantifier.GreaterThan },
                 AutoCancel = new RangeModel { StartValue = 5, RangeQuantifier = RangeQuantifier.GreaterThanOrEqualTo },
@@ -92,7 +92,7 @@ namespace FrannHammer.Services.Tests.MoveSearch
         [Test]
         public void ReturnsResultsForMultipleSearchAttributes()
         {
-            var searchModel = new ComplexMoveSearchModel
+            var searchModel = new MoveSearchModel
             {
                 Angle = new RangeModel { StartValue = 10, RangeQuantifier = RangeQuantifier.GreaterThan },
                 AutoCancel = new RangeModel { StartValue = 5, RangeQuantifier = RangeQuantifier.GreaterThanOrEqualTo },
@@ -107,7 +107,7 @@ namespace FrannHammer.Services.Tests.MoveSearch
         [TestCaseSource(nameof(Ranges))]
         public void ReturnsBaseDamageOnlyResult(RangeModel rangeModel)
         {
-            var searchModel = new ComplexMoveSearchModel
+            var searchModel = new MoveSearchModel
             {
                 BaseDamage = rangeModel
             };
@@ -121,7 +121,7 @@ namespace FrannHammer.Services.Tests.MoveSearch
         [TestCaseSource(nameof(Ranges))]
         public void ReturnsHitboxActiveLengthOnlyResult(RangeModel rangeModel)
         {
-            var searchModel = new ComplexMoveSearchModel
+            var searchModel = new MoveSearchModel
             {
                 HitboxActiveLength = rangeModel
             };
@@ -136,7 +136,7 @@ namespace FrannHammer.Services.Tests.MoveSearch
         [TestCaseSource(nameof(Ranges))]
         public void ReturnsAngleOnlyResult(RangeModel rangeModel)
         {
-            var searchModel = new ComplexMoveSearchModel
+            var searchModel = new MoveSearchModel
             {
                 Angle = rangeModel
             };
@@ -154,7 +154,7 @@ namespace FrannHammer.Services.Tests.MoveSearch
         [TestCase(" Ftilt 2 ")]
         public void ReturnsNameOnlyResult(string valueUnderTest)
         {
-            var model = new ComplexMoveSearchModel
+            var model = new MoveSearchModel
             {
                 Name = valueUnderTest
             };
@@ -175,7 +175,7 @@ namespace FrannHammer.Services.Tests.MoveSearch
         [TestCase(" Bowser Jr ")]
         public void ReturnsCharacterNameOnlyResult(string valueUnderTest)
         {
-            var model = new ComplexMoveSearchModel
+            var model = new MoveSearchModel
             {
                 CharacterName = valueUnderTest
             };

--- a/FrannHammer.Services.Tests/MoveSearch/MoveSearchModelRedisServiceTest.cs
+++ b/FrannHammer.Services.Tests/MoveSearch/MoveSearchModelRedisServiceTest.cs
@@ -1,0 +1,55 @@
+﻿using FrannHammer.Models;
+using FrannHammer.Services.MoveSearch;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace FrannHammer.Services.Tests.MoveSearch
+{
+    [TestFixture]
+    public class MoveSearchModelRedisServiceTest
+    {
+        [Test]
+        public void ConvertsToExpectedRedisKey()
+        {
+            //string expected =
+            //    $"{nameof(MoveSearchModel.Name)}:jab 1;" +
+            //    $"{nameof(MoveSearchModel.CharacterName)}:mario;" +
+            //    $"{nameof(MoveSearchModel.Angle)}:{nameof(RangeModel.StartValue)}:10,{nameof(RangeModel.RangeQuantifier)}:{nameof(RangeQuantifier.GreaterThan)},{nameof(RangeModel.EndValue)}:0;" +
+            //    $"{nameof(MoveSearchModel.AutoCancel)}:{nameof(RangeModel.StartValue)}:5,{nameof(RangeModel.RangeQuantifier)}:{nameof(RangeQuantifier.GreaterThanOrEqualTo)},{nameof(RangeModel.EndValue)}:0;" +
+            //    $"{nameof(MoveSearchModel.BaseDamage)}:{nameof(RangeModel.StartValue)}:3,{nameof(RangeModel.RangeQuantifier)}:{nameof(RangeQuantifier.LessThanOrEqualTo)},{nameof(RangeModel.EndValue)}:0;" +
+            //    $"{nameof(MoveSearchModel.BaseKnockback)}:{nameof(RangeModel.StartValue)}:50,{nameof(RangeModel.RangeQuantifier)}:{nameof(RangeQuantifier.GreaterThan)},{nameof(RangeModel.EndValue)}:0;" +
+            //    $"{nameof(MoveSearchModel.FirstActionableFrame)}:{nameof(RangeModel.StartValue)}:30,{nameof(RangeModel.RangeQuantifier)}:{nameof(RangeQuantifier.Between)},{nameof(RangeModel.EndValue)}:40;" +
+            //    $"{nameof(MoveSearchModel.HitboxActiveLength)}:{nameof(RangeModel.StartValue)}:1,{nameof(RangeModel.RangeQuantifier)}:{nameof(RangeQuantifier.GreaterThan)},{nameof(RangeModel.EndValue)}:0;" +
+            //    $"{nameof(MoveSearchModel.HitboxActiveOnFrame)}:{nameof(RangeModel.StartValue)}:2,{nameof(RangeModel.RangeQuantifier)}:{nameof(RangeQuantifier.GreaterThan)},{nameof(RangeModel.EndValue)}:0;" +
+            //    $"{nameof(MoveSearchModel.HitboxStartupFrame)}:{nameof(RangeModel.StartValue)}:3,{nameof(RangeModel.RangeQuantifier)}:{nameof(RangeQuantifier.GreaterThanOrEqualTo)},{nameof(RangeModel.EndValue)}:0;" +
+            //    $"{nameof(MoveSearchModel.KnockbackGrowth)}:{nameof(RangeModel.StartValue)}:30,{nameof(RangeModel.RangeQuantifier)}:{nameof(RangeQuantifier.LessThanOrEqualTo)},{nameof(RangeModel.EndValue)}:0;" +
+            //    $"{nameof(MoveSearchModel.LandingLag)}:" +
+            //    $"{nameof(MoveSearchModel.SetKnockback)}:;";
+
+            var searchModel = new MoveSearchModel
+            {
+                Angle = new RangeModel { StartValue = 10, RangeQuantifier = RangeQuantifier.GreaterThan },
+                AutoCancel = new RangeModel { StartValue = 5, RangeQuantifier = RangeQuantifier.GreaterThanOrEqualTo },
+                BaseDamage = new RangeModel { StartValue = 3, RangeQuantifier = RangeQuantifier.LessThanOrEqualTo },
+                BaseKnockback = new RangeModel { StartValue = 50, RangeQuantifier = RangeQuantifier.GreaterThan },
+                FirstActionableFrame =
+                    new RangeModel { StartValue = 30, RangeQuantifier = RangeQuantifier.Between, EndValue = 40 },
+                HitboxActiveLength = new RangeModel { StartValue = 1, RangeQuantifier = RangeQuantifier.GreaterThan },
+                HitboxActiveOnFrame = new RangeModel { StartValue = 2, RangeQuantifier = RangeQuantifier.GreaterThan },
+                HitboxStartupFrame =
+                    new RangeModel { StartValue = 3, RangeQuantifier = RangeQuantifier.GreaterThanOrEqualTo },
+                KnockbackGrowth = new RangeModel { StartValue = 30, RangeQuantifier = RangeQuantifier.LessThanOrEqualTo },
+                Name = "jab 1",
+                CharacterName = "mario"
+            };
+
+            string expected = JsonConvert.SerializeObject(searchModel);
+
+            var service = new MoveSearchModelRedisService();
+
+            var actualRedisKey = service.MoveSearchModelToRedisKey(searchModel);
+
+            Assert.That(actualRedisKey, Is.EqualTo(expected));
+        }
+    }
+}

--- a/FrannHammer.Services.Tests/Suts/MoveSearchSut.cs
+++ b/FrannHammer.Services.Tests/Suts/MoveSearchSut.cs
@@ -6,10 +6,10 @@ namespace FrannHammer.Services.Tests.Suts
 {
     public class MoveSearchSut
     {
-        public IEnumerable<dynamic> GetAll(ComplexMoveSearchModel searchModel, IApplicationDbContext context,
+        public IEnumerable<dynamic> GetAll(MoveSearchModel searchModel, IApplicationDbContext context,
            IResultValidationService resultValidationService, string fields = "")
         {
-            return new MetadataService(context, resultValidationService).GetAll<MoveDto>(searchModel, fields);
+            return new MetadataService(context, resultValidationService).GetAll<MoveDto>(searchModel, null, fields);
         }
     }
 }

--- a/FrannHammer.Services.Tests/packages.config
+++ b/FrannHammer.Services.Tests/packages.config
@@ -7,6 +7,8 @@
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net452" />
   <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.1" targetFramework="net452" />
   <package id="Moq" version="4.5.21" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NMemory" version="1.1.0" targetFramework="net452" />
   <package id="NUnit" version="3.4.1" targetFramework="net452" />
+  <package id="StackExchange.Redis" version="1.1.608" targetFramework="net452" />
 </packages>

--- a/FrannHammer.Services/App.config
+++ b/FrannHammer.Services/App.config
@@ -15,7 +15,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/FrannHammer.Services/FrannHammer.Services.csproj
+++ b/FrannHammer.Services/FrannHammer.Services.csproj
@@ -51,9 +51,18 @@
       <HintPath>..\packages\Microsoft.AspNet.Identity.EntityFramework.2.2.1\lib\net45\Microsoft.AspNet.Identity.EntityFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="StackExchange.Redis, Version=1.1.608.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.1.608\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -65,6 +74,7 @@
     <Compile Include="MoveSearch\AutoCancelSearchPredicateService.cs" />
     <Compile Include="BaseService.cs" />
     <Compile Include="MoveSearch\CharacterNameSearchPredicateService.cs" />
+    <Compile Include="MoveSearch\MoveSearchModelRedisService.cs" />
     <Compile Include="MoveSearch\DataParsingService.cs" />
     <Compile Include="MoveSearch\FirstActionableFrameSearchPredicateService.cs" />
     <Compile Include="MoveSearch\HitboxActiveLengthSearchPredicateService.cs" />

--- a/FrannHammer.Services/MoveSearch/MoveSearchModelRedisService.cs
+++ b/FrannHammer.Services/MoveSearch/MoveSearchModelRedisService.cs
@@ -1,0 +1,38 @@
+﻿using FrannHammer.Models;
+using Newtonsoft.Json;
+
+namespace FrannHammer.Services.MoveSearch
+{
+    public class MoveSearchModelRedisService
+    {
+        public string MoveSearchModelToRedisKey(MoveSearchModel moveSearchModel)
+        {
+            return moveSearchModel == null ? string.Empty : JsonConvert.SerializeObject(moveSearchModel);
+
+            //return $"{nameof(moveSearchModel.Name)}:{moveSearchModel.Name};" +
+            //       $"{nameof(MoveSearchModel.CharacterName)}:{moveSearchModel.CharacterName};" +
+            //       $"{nameof(MoveSearchModel.Angle)}:{RangeModelToRedisKey(moveSearchModel.Angle)}" +
+            //       $"{nameof(MoveSearchModel.AutoCancel)}:{RangeModelToRedisKey(moveSearchModel.AutoCancel)}" +
+            //       $"{nameof(MoveSearchModel.BaseDamage)}:{RangeModelToRedisKey(moveSearchModel.BaseDamage)}" +
+            //       $"{nameof(MoveSearchModel.BaseKnockback)}:{RangeModelToRedisKey(moveSearchModel.BaseKnockback)}" +
+            //       $"{nameof(MoveSearchModel.FirstActionableFrame)}:{RangeModelToRedisKey(moveSearchModel.FirstActionableFrame)}" +
+            //       $"{nameof(MoveSearchModel.HitboxActiveLength)}:{RangeModelToRedisKey(moveSearchModel.HitboxActiveLength)}" +
+            //       $"{nameof(MoveSearchModel.HitboxActiveOnFrame)}:{RangeModelToRedisKey(moveSearchModel.HitboxActiveOnFrame)}" +
+            //       $"{nameof(MoveSearchModel.HitboxStartupFrame)}:{RangeModelToRedisKey(moveSearchModel.HitboxStartupFrame)}" +
+            //       $"{nameof(MoveSearchModel.KnockbackGrowth)}:{RangeModelToRedisKey(moveSearchModel.KnockbackGrowth)}" +
+            //       $"{nameof(MoveSearchModel.LandingLag)}:{RangeModelToRedisKey(moveSearchModel.LandingLag)}" +
+            //       $"{nameof(MoveSearchModel.SetKnockback)}:{RangeModelToRedisKey(moveSearchModel.SetKnockback)};";
+        }
+
+        private string RangeModelToRedisKey(RangeModel rangeModel)
+        {
+            if (rangeModel == null)
+            {
+                return string.Empty;
+            }
+
+            return $"{nameof(RangeModel.StartValue)}:{rangeModel.StartValue},{nameof(RangeModel.RangeQuantifier)}:{rangeModel.RangeQuantifier}," +
+                   $"{nameof(RangeModel.EndValue)}:{rangeModel.EndValue};";
+        }
+    }
+}

--- a/FrannHammer.Services/MoveSearch/SearchPredicateFactory.cs
+++ b/FrannHammer.Services/MoveSearch/SearchPredicateFactory.cs
@@ -43,7 +43,7 @@ namespace FrannHammer.Services.MoveSearch
             _hitboxActiveLengthSearchPredicateService = new HitboxActiveLengthSearchPredicateService();
         }
 
-        public void CreateSearchPredicates(ComplexMoveSearchModel searchModel)
+        public void CreateSearchPredicates(MoveSearchModel searchModel)
         {
             HitboxActiveLengthPredicate = CreateHitboxActiveLengthPredicate(searchModel);
             HitboxStartupPredicate = CreateHitboxStartupPredicate(searchModel);
@@ -60,43 +60,43 @@ namespace FrannHammer.Services.MoveSearch
             AutocancelPredicate = CreateAutocancelPredicate(searchModel);
         }
 
-        private Func<Hitbox, bool> CreateHitboxActiveLengthPredicate(ComplexMoveSearchModel searchModel)
+        private Func<Hitbox, bool> CreateHitboxActiveLengthPredicate(MoveSearchModel searchModel)
             => _hitboxActiveLengthSearchPredicateService.GetHitboxActiveLengthPredicate(searchModel.HitboxActiveLength);
 
-        private Func<Autocancel, bool> CreateAutocancelPredicate(ComplexMoveSearchModel searchModel)
+        private Func<Autocancel, bool> CreateAutocancelPredicate(MoveSearchModel searchModel)
             => _autocancelSearchPredicateService.GetAutoCancelSearchPredicate(searchModel.AutoCancel);
 
-        private Func<Hitbox, bool> CreateHitboxStartupPredicate(ComplexMoveSearchModel searchModel)
+        private Func<Hitbox, bool> CreateHitboxStartupPredicate(MoveSearchModel searchModel)
             => _baseMoveHitboxPredicateService.GetPredicate<Hitbox>(searchModel.HitboxStartupFrame);
 
-        private Func<BaseDamage, bool> CreateBaseDamagePredicate(ComplexMoveSearchModel searchModel)
+        private Func<BaseDamage, bool> CreateBaseDamagePredicate(MoveSearchModel searchModel)
             => _baseMoveHitboxPredicateService.GetPredicate<BaseDamage>(searchModel.BaseDamage);
 
-        private Func<Angle, bool> CreateAnglePredicate(ComplexMoveSearchModel searchModel)
+        private Func<Angle, bool> CreateAnglePredicate(MoveSearchModel searchModel)
             => _baseMoveHitboxPredicateService.GetPredicate<Angle>(searchModel.Angle);
 
-        private Func<BaseKnockback, bool> CreateBaseKnockbackPredicate(ComplexMoveSearchModel searchModel)
+        private Func<BaseKnockback, bool> CreateBaseKnockbackPredicate(MoveSearchModel searchModel)
             => _baseMoveHitboxPredicateService.GetPredicate<BaseKnockback>(searchModel.BaseKnockback);
 
-        private Func<SetKnockback, bool> CreateSetKnockbackPredicate(ComplexMoveSearchModel searchModel)
+        private Func<SetKnockback, bool> CreateSetKnockbackPredicate(MoveSearchModel searchModel)
            => _baseMoveHitboxPredicateService.GetPredicate<SetKnockback>(searchModel.SetKnockback);
 
-        private Func<KnockbackGrowth, bool> CreateKnockbackGrowthPredicate(ComplexMoveSearchModel searchModel)
+        private Func<KnockbackGrowth, bool> CreateKnockbackGrowthPredicate(MoveSearchModel searchModel)
            => _baseMoveHitboxPredicateService.GetPredicate<KnockbackGrowth>(searchModel.KnockbackGrowth);
 
-        private Func<Hitbox, bool> CreateHitboxActiveOnFramePredicate(ComplexMoveSearchModel searchModel)
+        private Func<Hitbox, bool> CreateHitboxActiveOnFramePredicate(MoveSearchModel searchModel)
             => _hitboxActiveSearchPredicateService.GetHitboxActivePredicate(searchModel.HitboxActiveOnFrame);
 
-        private Func<Move, bool> CreateFirstActionableFramePredicate(ComplexMoveSearchModel searchModel)
+        private Func<Move, bool> CreateFirstActionableFramePredicate(MoveSearchModel searchModel)
            => _firstActionableFrameSearchPredicateService.GetFirstActionableFrameSearchPredicate(searchModel.FirstActionableFrame);
 
-        private Func<LandingLag, bool> CreateLandingLagPredicate(ComplexMoveSearchModel searchModel)
+        private Func<LandingLag, bool> CreateLandingLagPredicate(MoveSearchModel searchModel)
             => _landingLagSearchPredicateService.GetLandingLagSearchPredicate(searchModel.LandingLag);
 
-        private Func<Move, bool> CreateNamePredicate(ComplexMoveSearchModel searchModel)
+        private Func<Move, bool> CreateNamePredicate(MoveSearchModel searchModel)
             => _nameSearchPredicateService.GetNamePredicate(searchModel.Name);
 
-        private Func<Character, bool> CreateCharacterNamePredicate(ComplexMoveSearchModel searchModel)
+        private Func<Character, bool> CreateCharacterNamePredicate(MoveSearchModel searchModel)
             => _characterNameSearchPredicateService.GetCharacterNamePredicate(searchModel.CharacterName);
 
 

--- a/FrannHammer.Services/packages.config
+++ b/FrannHammer.Services/packages.config
@@ -4,4 +4,6 @@
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net452" />
   <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.1.608" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Uses StackExchange.Redis libraries to interface with Redis for Window 64-bit local instance (staying away from Azure for now)
- Add key check and key creation to MoveSearchModel objects and MetadataService.GetAll for move search methods
- Added Json.NET packages across services and Api projects to use as redis key creation.  MoveSearchModel objects are serialized to json and then the json is used as a RedisKey.  
- The results of a query for move search data are used as the RedisValue.
- Initial testing reduces search times by several orders of magnitude once initial search is cached in memory using Redis.