### PR TITLE
Completes Issue #146

### DIFF
--- a/FrannHammer.Api.Data.Tests/CharacterIntegrityTest.cs
+++ b/FrannHammer.Api.Data.Tests/CharacterIntegrityTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Web.Http.Results;
 using FrannHammer.Api.Controllers;
 using FrannHammer.Models.DTOs;
@@ -73,5 +74,32 @@ namespace FrannHammer.Api.Data.Tests
             Assert.That(response.Content.Metadata, Is.Not.Null);
             Assert.That(response.Content.MovementData, Is.Not.Null);
         }
+
+        [Test]
+        [TestCase(23)]
+        public void DetailsMoveDataIsAggregatedAsExpected(int characterId)
+        {
+            var metadataService = new MetadataService(Context, new ResultValidationService());
+            var controller = new CharactersController(metadataService);
+
+            var response = controller.GetDetailedMovesForCharacter(characterId) as OkNegotiatedContentResult<IEnumerable<DetailedMoveDto>>;
+
+            Assert.That(response, Is.Not.Null);
+
+            CollectionAssert.AllItemsAreUnique(response.Content);
+            CollectionAssert.IsNotEmpty(response.Content);
+
+            foreach (var detailedMove in response.Content)
+            {
+                // ReSharper disable once PossibleNullReferenceException
+                Assert.That(detailedMove.MoveId, Is.GreaterThan(0));
+                Assert.That(detailedMove.MoveName, Is.Not.Empty);
+            }
+        }
+
+        //TODO:
+        //test for invalid character id
+        //test that properties return empty if nothing found
+        //test that properties contain expected information
     }
 }

--- a/FrannHammer.Api/App_Data/XmlDocument.xml
+++ b/FrannHammer.Api/App_Data/XmlDocument.xml
@@ -362,6 +362,15 @@
             E.g., id,name to get back just the id and name.</para></param> 
             <returns></returns>
         </member>
+        <member name="M:FrannHammer.Api.Controllers.CharactersController.GetDetailedMovesForCharacterByName(System.String,System.String)">
+            <summary>
+            Get all the <see cref="T:FrannHammer.Models.Move"/> data for a specific <see cref="T:FrannHammer.Models.Character"/> broken out
+            into stronger typed response objects.  This is designed to make sifting through the data easier.
+            </summary>
+            <param name="name"></param>
+            <param name="fields"></param>
+            <returns></returns>
+        </member>
         <member name="M:FrannHammer.Api.Controllers.CharactersController.GetMovementsForCharacter(System.Int32,System.String)">
             <summary>
             Get all the <see cref="T:FrannHammer.Models.Movement"/> data for a specific <see cref="T:FrannHammer.Models.Character"/>
@@ -378,6 +387,15 @@
             <param name="id"></param>
             <param name="fields">Specify which specific pieces of the response model you need via comma-separated values. <para> 
             E.g., id,name to get back just the id and name.</para></param> 
+            <returns></returns>
+        </member>
+        <member name="M:FrannHammer.Api.Controllers.CharactersController.GetDetailedMovesForCharacter(System.Int32,System.String)">
+            <summary>
+            Get all the <see cref="T:FrannHammer.Models.Move"/> data for a specific <see cref="T:FrannHammer.Models.Character"/> broken out
+            into stronger typed response objects.  This is designed to make sifting through the data easier.
+            </summary>
+            <param name="id"></param>
+            <param name="fields"></param>
             <returns></returns>
         </member>
         <member name="M:FrannHammer.Api.Controllers.CharactersController.GetThrowsForCharacter(System.Int32,System.String)">
@@ -663,6 +681,24 @@
         <member name="M:FrannHammer.Api.Controllers.MovesController.GetMoveHitboxData(System.Int32,System.String)">
             <summary>
             Get the <see cref="T:FrannHammer.Models.Hitbox"/> data associated with this move.
+            </summary>
+            <param name="id"></param>
+            <param name="fields">Specify which specific pieces of the response model you need via comma-separated values. <para> 
+            E.g., id,name to get back just the id and name.</para></param>
+            <returns></returns>
+        </member>
+        <member name="M:FrannHammer.Api.Controllers.MovesController.GetMoveAutocancelData(System.Int32,System.String)">
+            <summary>
+            Get the <see cref="T:FrannHammer.Models.Autocancel"/> data associated with this move.
+            </summary>
+            <param name="id"></param>
+            <param name="fields">Specify which specific pieces of the response model you need via comma-separated values. <para> 
+            E.g., id,name to get back just the id and name.</para></param>
+            <returns></returns>
+        </member>
+        <member name="M:FrannHammer.Api.Controllers.MovesController.GetMoveLandingLagData(System.Int32,System.String)">
+            <summary>
+            Get the <see cref="T:FrannHammer.Models.LandingLag"/> data associated with this move.
             </summary>
             <param name="id"></param>
             <param name="fields">Specify which specific pieces of the response model you need via comma-separated values. <para> 

--- a/FrannHammer.Api/Controllers/CharactersController.cs
+++ b/FrannHammer.Api/Controllers/CharactersController.cs
@@ -156,6 +156,29 @@ namespace FrannHammer.Api.Controllers
         }
 
         /// <summary>
+        /// Get all the <see cref="Move"/> data for a specific <see cref="Character"/> broken out
+        /// into stronger typed response objects.  This is designed to make sifting through the data easier.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="fields"></param>
+        /// <returns></returns>
+        [Route(CharactersRouteKey + "/name/{name}/detailedmoves")]
+        public IHttpActionResult GetDetailedMovesForCharacterByName(string name, [FromUri] string fields = "")
+        {
+            var nameContent = _metadataService.Get<Character, CharacterDto>(c => c.Name.Equals(name, StringComparison.OrdinalIgnoreCase), "id", false);
+
+            if (nameContent == null)
+            {
+                return NotFound();
+            }
+
+            int id = nameContent.Id;
+
+            var content = _metadataService.GetDetailsForMovesOfCharacter(id, fields);
+            return Ok(content);
+        }
+
+        /// <summary>
         /// Get all the <see cref="Movement"/> data for a specific <see cref="Character"/>
         /// </summary>
         /// <param name="id"></param>
@@ -185,6 +208,20 @@ namespace FrannHammer.Api.Controllers
         public IHttpActionResult GetMovesForCharacter(int id, [FromUri] string fields = "")
         {
             var content = _metadataService.GetAll<Move, MoveDto>(m => m.OwnerId == id, fields);
+            return Ok(content);
+        }
+
+        /// <summary>
+        /// Get all the <see cref="Move"/> data for a specific <see cref="Character"/> broken out
+        /// into stronger typed response objects.  This is designed to make sifting through the data easier.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="fields"></param>
+        /// <returns></returns>
+        [Route(CharactersRouteKey + "/{id}/detailedmoves")]
+        public IHttpActionResult GetDetailedMovesForCharacter(int id, [FromUri] string fields = "")
+        {
+            var content = _metadataService.GetDetailsForMovesOfCharacter(id, fields);
             return Ok(content);
         }
 

--- a/FrannHammer.Api/Controllers/MovesController.cs
+++ b/FrannHammer.Api/Controllers/MovesController.cs
@@ -95,6 +95,38 @@ namespace FrannHammer.Api.Controllers
         }
 
         /// <summary>
+        /// Get the <see cref="Autocancel"/> data associated with this move.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="fields">Specify which specific pieces of the response model you need via comma-separated values. <para> 
+        /// E.g., id,name to get back just the id and name.</para></param>
+        /// <returns></returns>
+        [ResponseType(typeof(AutocancelDto))]
+        [ValidateModel]
+        [Route(MovesRouteKey + "/{id}/autocancel")]
+        public IHttpActionResult GetMoveAutocancelData(int id, [FromUri] string fields = "")
+        {
+            var content = _metadataService.GetWithMoves<Autocancel, AutocancelDto>(id, fields);
+            return Ok(content);
+        }
+
+        /// <summary>
+        /// Get the <see cref="LandingLag"/> data associated with this move.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="fields">Specify which specific pieces of the response model you need via comma-separated values. <para> 
+        /// E.g., id,name to get back just the id and name.</para></param>
+        /// <returns></returns>
+        [ResponseType(typeof(LandingLagDto))]
+        [ValidateModel]
+        [Route(MovesRouteKey + "/{id}/landinglag")]
+        public IHttpActionResult GetMoveLandingLagData(int id, [FromUri] string fields = "")
+        {
+            var content = _metadataService.GetWithMoves<LandingLag, LandingLagDto>(id, fields);
+            return Ok(content);
+        }
+
+        /// <summary>
         /// Get the <see cref="BaseKnockback"/> data associated with this move.
         /// </summary>
         /// <param name="id"></param>

--- a/FrannHammer.Api/Startup.cs
+++ b/FrannHammer.Api/Startup.cs
@@ -30,6 +30,10 @@ namespace FrannHammer.Api
         {
             Mapper.Initialize(cfg =>
             {
+                cfg.CreateMap<Autocancel, AutocancelDto>();
+                cfg.CreateMap<AutocancelDto, Autocancel>();
+                cfg.CreateMap<LandingLag, LandingLagDto>();
+                cfg.CreateMap<LandingLagDto, LandingLag>();
                 cfg.CreateMap<Throw, ThrowDto>();
                 cfg.CreateMap<ThrowDto, Throw>();
                 cfg.CreateMap<ThrowType, ThrowTypeDto>();

--- a/FrannHammer.Models/DTOs/DetailedMoveDto.cs
+++ b/FrannHammer.Models/DTOs/DetailedMoveDto.cs
@@ -1,0 +1,18 @@
+﻿namespace FrannHammer.Models.DTOs
+{
+    public class DetailedMoveDto
+    {
+        public int MoveId { get; set; }
+        public string MoveName { get; set; }
+        public dynamic Angle { get; set; }
+        public dynamic Hitbox { get; set; }
+        public dynamic BaseDamage { get; set; }
+        public dynamic BaseKnockback { get; set; }
+        public dynamic SetKnockback { get; set; }
+
+        //TODO: These three props need to be exposed in the MovesController as well (and metadataservice).
+        public dynamic Autocancel { get; set; }
+        public dynamic LandingLag { get; set; }
+        //public dynamic Throws { get; set; }
+    }
+}

--- a/FrannHammer.Models/FrannHammer.Models.csproj
+++ b/FrannHammer.Models/FrannHammer.Models.csproj
@@ -89,6 +89,7 @@
     <Compile Include="CharacterAttributeModels.cs" />
     <Compile Include="CharacterAttributeType.cs" />
     <Compile Include="DTOs\AggregateCharacterData.cs" />
+    <Compile Include="DTOs\DetailedMoveDto.cs" />
     <Compile Include="MoveSearchModel.cs" />
     <Compile Include="DTOs\BaseMoveHitboxMetaDto.cs" />
     <Compile Include="DTOs\CalculatorDtos.cs" />

--- a/FrannHammer.Models/MoveMetadataModels.cs
+++ b/FrannHammer.Models/MoveMetadataModels.cs
@@ -43,12 +43,34 @@ namespace FrannHammer.Models
         public string Hitbox6 { get; set; }
     }
 
-    public class LandingLag : BaseMeta
+    public class BaseMetaDto
+    {
+        public int Id { get; set; }
+        public int OwnerId { get; set; }
+        public int MoveId { get; set; }
+        public string MoveName { get; set; }
+        public string Notes { get; set; }
+        public string RawValue { get; set; }
+        public DateTime LastModified { get; set; }
+    }
+
+    public class LandingLagDto : BaseMetaDto, IMoveIdEntity
     {
         public int Frames { get; set; }
     }
 
-    public class Autocancel : BaseMeta
+    public class LandingLag : BaseMeta, IMoveIdEntity
+    {
+        public int Frames { get; set; }
+    }
+
+    public class AutocancelDto : BaseMetaDto, IMoveIdEntity
+    {
+        public string Cancel1 { get; set; }
+        public string Cancel2 { get; set; }
+    }
+
+    public class Autocancel : BaseMeta, IMoveIdEntity
     {
         public string Cancel1 { get; set; }
         public string Cancel2 { get; set; }

--- a/FrannHammer.Services/BaseService.cs
+++ b/FrannHammer.Services/BaseService.cs
@@ -79,10 +79,10 @@ namespace FrannHammer.Services
         protected dynamic BuildContentResponse<TEntity, TDto>(TEntity entity, string fields)
             where TEntity : class
         {
-            if (entity == null)
-            { throw new EntityNotFoundException($"Unable to find any entities of type '{typeof(TEntity).Name}'"); }
+            //if (entity == null)
+            //{ throw new EntityNotFoundException($"Unable to find any entities of type '{typeof(TEntity).Name}'"); }
 
-            return DtoBuilder.Build<TEntity, TDto>(entity, fields);
+            return entity != null ? DtoBuilder.Build<TEntity, TDto>(entity, fields) : default(dynamic);
         }
 
         protected IEnumerable<dynamic> BuildContentResponseMultiple<TEntity, TDto>(IList<TEntity> entities,

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,6 @@
 #addin nuget:?package=Cake.Git
 #addin "Cake.WebDeploy"
+#addin "Cake.Powershell"
 
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS


### PR DESCRIPTION
- Added moves/{id}/landinglag
- Added moves/{id}/autocancel
- Added support for bringing back all of a character's move data using the strongly typed model instead of raw move table entries