### PR TITLE
- Initial changes for Issue #169

### DIFF
--- a/FrannHammer.Models/DTOs/DetailedMoveDto.cs
+++ b/FrannHammer.Models/DTOs/DetailedMoveDto.cs
@@ -9,10 +9,11 @@
         public dynamic BaseDamage { get; set; }
         public dynamic BaseKnockback { get; set; }
         public dynamic SetKnockback { get; set; }
-
-        //TODO: These three props need to be exposed in the MovesController as well (and metadataservice).
+        public string FirstActionableFrame { get; set; }
         public dynamic Autocancel { get; set; }
         public dynamic LandingLag { get; set; }
+
+        //TODO: No good way to expose this here yet.
         //public dynamic Throws { get; set; }
     }
 }

--- a/FrannHammer.Services/MetadataService.cs
+++ b/FrannHammer.Services/MetadataService.cs
@@ -207,7 +207,7 @@ namespace FrannHammer.Services
         public IEnumerable<DetailedMoveDto> GetDetailsForMovesOfCharacter(int id, string fields = "")
         {
             // get all moveIds for moves for character specified by id
-            var moveData = GetAll<Move, MoveDto>(m => m.OwnerId == id, $"{nameof(Move.Id)},{nameof(Move.Name)}").ToList();
+            var moveData = GetAll<Move, MoveDto>(m => m.OwnerId == id, $"{nameof(Move.Id)},{nameof(Move.Name)},{nameof(Move.FirstActionableFrame)}").ToList();
 
             //all move attribute tables have these same columns.  We don't need the metadata (ownerid, name, etc.) since 
             //we have that from the above call.
@@ -244,6 +244,14 @@ namespace FrannHammer.Services
                         Autocancel = autoCancels,
                         LandingLag = landingLags
                     };
+
+                    //only add faf if it's not empty or just contains a '-'
+                    string faf = (string) data.FirstActionableFrame;
+                    
+                    if (!string.IsNullOrEmpty(faf) && !faf.Equals("-"))
+                    {
+                        detailedMoveDto.FirstActionableFrame = faf;
+                    }
 
                     detailedMoves.Add(detailedMoveDto);
                 }


### PR DESCRIPTION
- Added support for string type FirstActionableFrame property on DetailedMoveDto
- Modified service call that returns detailed move data to include FirstActionableFrame data from Moves table before aggregating into dto.  FAF data will only be included if valid since there is no FAF table for strong-typing.