### PR TITLE
- Actually added support for searching moves via move property criteria on character controller

### DIFF
--- a/FrannHammer.Api.Services.Contracts/ICharacterService.cs
+++ b/FrannHammer.Api.Services.Contracts/ICharacterService.cs
@@ -16,7 +16,6 @@ namespace FrannHammer.Api.Services.Contracts
         IEnumerable<ICharacterAttributeRow> GetAllAttributesWhereCharacterOwnerIdIs(int id, string fields = "");
         IEnumerable<ParsedMove> GetDetailedMovesWhereCharacterOwnerIdIs(int id, string fields = "");
 
-        //new
         IEnumerable<IMove> GetAllThrowsWhereCharacterOwnerIdIs(int id, string fields = "");
         IEnumerable<IMove> GetAllThrowsWhereCharacterNameIs(string name, string fields = "");
 
@@ -25,5 +24,8 @@ namespace FrannHammer.Api.Services.Contracts
 
         IEnumerable<IMove> GetAllMovesForCharacterByNameFilteredBy(IMoveFilterResourceQuery query);
         IEnumerable<IMove> GetAllMovesForCharacterByOwnerIdFilteredBy(IMoveFilterResourceQuery query);
+
+        IEnumerable<IMovement> GetAllMovementsWhereCharacterOwnerIdIsFilteredBy(IMovementFilterResourceQuery query);
+        IEnumerable<IMovement> GetAllMovementsWhereCharacterNameIsFilteredBy(IMovementFilterResourceQuery query);
     }
 }

--- a/FrannHammer.Api.Services.Contracts/IMovementService.cs
+++ b/FrannHammer.Api.Services.Contracts/IMovementService.cs
@@ -7,5 +7,6 @@ namespace FrannHammer.Api.Services.Contracts
     {
         IEnumerable<IMovement> GetAllWhereCharacterNameIs(string name, string fields = "");
         IEnumerable<IMovement> GetAllWhereCharacterOwnerIdIs(int id, string fields = "");
+        IEnumerable<IMovement> GetAllWhere(IFilterResourceQuery query, string fields = "");
     }
 }

--- a/FrannHammer.Api.Services.Tests/ApiServiceFactories/DefaultCharacterServiceFactory.cs
+++ b/FrannHammer.Api.Services.Tests/ApiServiceFactories/DefaultCharacterServiceFactory.cs
@@ -9,7 +9,8 @@ namespace FrannHammer.Api.Services.Tests.ApiServiceFactories
     {
         public override ICrudService<ICharacter> CreateService(IRepository<ICharacter> repository)
         {
-            return new DefaultCharacterService(repository, new DefaultDtoProvider(), new DefaultMovementService(new Mock<IRepository<IMovement>>().Object),
+            return new DefaultCharacterService(repository, new DefaultDtoProvider(), 
+                new DefaultMovementService(new Mock<IRepository<IMovement>>().Object, new Mock<IQueryMappingService>().Object),
                 new DefaultCharacterAttributeService(new Mock<IRepository<ICharacterAttributeRow>>().Object),
                 new DefaultMoveService(new Mock<IRepository<IMove>>().Object, new QueryMappingService(new Mock<IAttributeStrategy>().Object)));
         }

--- a/FrannHammer.Api.Services.Tests/ApiServiceFactories/MovementApiServiceFactory.cs
+++ b/FrannHammer.Api.Services.Tests/ApiServiceFactories/MovementApiServiceFactory.cs
@@ -8,7 +8,7 @@ namespace FrannHammer.Api.Services.Tests.ApiServiceFactories
     {
         public override ICrudService<IMovement> CreateService(IRepository<IMovement> repository)
         {
-            return new DefaultMovementService(repository);
+            return new DefaultMovementService(repository, new QueryMappingService(new DefaultAttributeStrategy()));
         }
     }
 }

--- a/FrannHammer.Api.Services.Tests/DefaultCharacterServiceTests.cs
+++ b/FrannHammer.Api.Services.Tests/DefaultCharacterServiceTests.cs
@@ -17,7 +17,7 @@ namespace FrannHammer.Api.Services.Tests
                 // ReSharper disable once ObjectCreationAsStatement
                 new DefaultCharacterService(null,
                     new DefaultDtoProvider(),
-                    new DefaultMovementService(new Mock<IRepository<IMovement>>().Object),
+                    new DefaultMovementService(new Mock<IRepository<IMovement>>().Object, new Mock<IQueryMappingService>().Object),
                     new DefaultCharacterAttributeService(new Mock<IRepository<ICharacterAttributeRow>>().Object),
                     new DefaultMoveService(new Mock<IRepository<IMove>>().Object, new QueryMappingService(new Mock<IAttributeStrategy>().Object)));
             });

--- a/FrannHammer.Api.Services.Tests/DefaultMovementServiceTests.cs
+++ b/FrannHammer.Api.Services.Tests/DefaultMovementServiceTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Moq;
 using NUnit.Framework;
 
 namespace FrannHammer.Api.Services.Tests
@@ -12,10 +13,8 @@ namespace FrannHammer.Api.Services.Tests
             Assert.Throws<ArgumentNullException>(() =>
             {
                 // ReSharper disable once ObjectCreationAsStatement
-                new DefaultMovementService(null);
+                new DefaultMovementService(null, new Mock<IQueryMappingService>().Object);
             });
         }
-
-
     }
 }

--- a/FrannHammer.Api.Services/DefaultCharacterService.cs
+++ b/FrannHammer.Api.Services/DefaultCharacterService.cs
@@ -143,5 +143,15 @@ namespace FrannHammer.Api.Services
         {
             return _moveService.GetAllWhere(query);
         }
+
+        public IEnumerable<IMovement> GetAllMovementsWhereCharacterOwnerIdIsFilteredBy(IMovementFilterResourceQuery query)
+        {
+            return _movementService.GetAllWhere(query);
+        }
+
+        public IEnumerable<IMovement> GetAllMovementsWhereCharacterNameIsFilteredBy(IMovementFilterResourceQuery query)
+        {
+            return _movementService.GetAllWhere(query);
+        }
     }
 }

--- a/FrannHammer.Api.Services/DefaultMovementService.cs
+++ b/FrannHammer.Api.Services/DefaultMovementService.cs
@@ -1,13 +1,29 @@
-﻿using FrannHammer.Api.Services.Contracts;
+﻿using System.Collections.Generic;
+using System.Reflection;
+using FrannHammer.Api.Services.Contracts;
 using FrannHammer.DataAccess.Contracts;
 using FrannHammer.Domain.Contracts;
+using FrannHammer.Utility;
 
 namespace FrannHammer.Api.Services
 {
     public class DefaultMovementService : OwnerBasedApiService<IMovement>, IMovementService
     {
-        public DefaultMovementService(IRepository<IMovement> repository)
+        private readonly IQueryMappingService _queryMappingService;
+
+        public DefaultMovementService(IRepository<IMovement> repository, IQueryMappingService queryMappingService)
             : base(repository)
-        { }
+        {
+            Guard.VerifyObjectNotNull(queryMappingService, nameof(queryMappingService));
+            _queryMappingService = queryMappingService;
+        }
+
+        public IEnumerable<IMovement> GetAllWhere(IFilterResourceQuery query, string fields = "")
+        {
+            var queryFilterParameters = _queryMappingService.MapResourceQueryToDictionary(query,
+                BindingFlags.Public | BindingFlags.Instance);
+
+            return GetAllWhere(queryFilterParameters);
+        }
     }
 }

--- a/FrannHammer.Api.Services/IQueryMappingService.cs
+++ b/FrannHammer.Api.Services/IQueryMappingService.cs
@@ -6,6 +6,6 @@ namespace FrannHammer.Api.Services
 {
     public interface IQueryMappingService
     {
-        IDictionary<string, object> MapResourceQueryToDictionary(IMoveFilterResourceQuery query, BindingFlags flagsToLocateProperties);
+        IDictionary<string, object> MapResourceQueryToDictionary(IFilterResourceQuery query, BindingFlags flagsToLocateProperties);
     }
 }

--- a/FrannHammer.Api.Services/QueryMappingService.cs
+++ b/FrannHammer.Api.Services/QueryMappingService.cs
@@ -17,7 +17,7 @@ namespace FrannHammer.Api.Services
             _attributeStrategy = attributeStrategy;
         }
 
-        public IDictionary<string, object> MapResourceQueryToDictionary(IMoveFilterResourceQuery query, BindingFlags flagsToLocateProperties)
+        public IDictionary<string, object> MapResourceQueryToDictionary(IFilterResourceQuery query, BindingFlags flagsToLocateProperties)
         {
             Guard.VerifyObjectNotNull(query, nameof(query));
 

--- a/FrannHammer.Domain.Contracts/FrannHammer.Domain.Contracts.csproj
+++ b/FrannHammer.Domain.Contracts/FrannHammer.Domain.Contracts.csproj
@@ -48,12 +48,14 @@
     <Compile Include="ICharacterAttributeRow.cs" />
     <Compile Include="ICharacter.cs" />
     <Compile Include="ICharacterDetailsDto.cs" />
+    <Compile Include="IFilterResourceQuery.cs" />
     <Compile Include="IHaveAnOwner.cs" />
     <Compile Include="IHaveAnOwnerId.cs" />
     <Compile Include="IModel.cs" />
     <Compile Include="IMove.cs" />
     <Compile Include="IMoveFilterResourceQuery.cs" />
     <Compile Include="IMovement.cs" />
+    <Compile Include="IMovementFilterResourceQuery.cs" />
     <Compile Include="IUniqueData.cs" />
     <Compile Include="IUniqueDataProvider.cs" />
     <Compile Include="MoveType.cs" />

--- a/FrannHammer.Domain.Contracts/IFilterResourceQuery.cs
+++ b/FrannHammer.Domain.Contracts/IFilterResourceQuery.cs
@@ -1,0 +1,6 @@
+﻿namespace FrannHammer.Domain.Contracts
+{
+    public interface IFilterResourceQuery
+    {
+    }
+}

--- a/FrannHammer.Domain.Contracts/IMoveFilterResourceQuery.cs
+++ b/FrannHammer.Domain.Contracts/IMoveFilterResourceQuery.cs
@@ -1,6 +1,6 @@
 ﻿namespace FrannHammer.Domain.Contracts
 {
-    public interface IMoveFilterResourceQuery
+    public interface IMoveFilterResourceQuery : IFilterResourceQuery
     {
         string Name { get; set; }
         string MoveName { get; set; }

--- a/FrannHammer.Domain.Contracts/IMovementFilterResourceQuery.cs
+++ b/FrannHammer.Domain.Contracts/IMovementFilterResourceQuery.cs
@@ -1,0 +1,8 @@
+﻿namespace FrannHammer.Domain.Contracts
+{
+    public interface IMovementFilterResourceQuery : IFilterResourceQuery
+    {
+        string MovementName { get; set; }
+        string Fields { get; set; }
+    }
+}

--- a/FrannHammer.Domain/FrannHammer.Domain.csproj
+++ b/FrannHammer.Domain/FrannHammer.Domain.csproj
@@ -55,6 +55,7 @@
     <Compile Include="MoveFilterResourceQuery.cs" />
     <Compile Include="FriendlyNameMoveCommonConstants.cs" />
     <Compile Include="Movement.cs" />
+    <Compile Include="MovementFilterResourceQuery.cs" />
     <Compile Include="MoveParseClassMap.cs" />
     <Compile Include="PropertyParsers\AutocancelParser.cs" />
     <Compile Include="PropertyParsers\BaseKnockbackParser.cs" />

--- a/FrannHammer.Domain/MovementFilterResourceQuery.cs
+++ b/FrannHammer.Domain/MovementFilterResourceQuery.cs
@@ -1,0 +1,12 @@
+﻿using FrannHammer.Domain.Contracts;
+
+namespace FrannHammer.Domain
+{
+    public class MovementFilterResourceQuery : IMovementFilterResourceQuery
+    {
+        [FriendlyName(FriendlyNameCommonConstants.Name)]
+        public string MovementName { get; set; }
+
+        public string Fields { get; set; }
+    }
+}

--- a/FrannHammer.Seeding.Tests/DefaultSeederIntegrationTests.cs
+++ b/FrannHammer.Seeding.Tests/DefaultSeederIntegrationTests.cs
@@ -117,9 +117,10 @@ namespace FrannHammer.Seeding.Tests
             var characterAttributeRepository = new MongoDbRepository<ICharacterAttributeRow>(MongoDatabase);
 
             //real api services using mocked repos
+            var mockQueryMappingService = new Mock<IQueryMappingService>().Object;
             var dtoProvider = new DefaultDtoProvider();
-            var movementService = new DefaultMovementService(movementRepository);
-            var moveService = new DefaultMoveService(moveRepository, new Mock<IQueryMappingService>().Object);
+            var movementService = new DefaultMovementService(movementRepository, mockQueryMappingService);
+            var moveService = new DefaultMoveService(moveRepository, mockQueryMappingService);
             var characterAttributeService = new DefaultCharacterAttributeService(characterAttributeRepository);
             var characterService = new DefaultCharacterService(characterRepository, dtoProvider, movementService, characterAttributeService, moveService);
 

--- a/FrannHammer.Seeding.Tests/DefaultSeederTests.cs
+++ b/FrannHammer.Seeding.Tests/DefaultSeederTests.cs
@@ -132,7 +132,7 @@ namespace FrannHammer.Seeding.Tests
             characterAttributeRepositoryMock.Setup(c => c.GetAll()).Returns(() => characterAttributes);
 
             //real api services using mocked repos
-            var movementService = new DefaultMovementService(movementRepositoryMock.Object);
+            var movementService = new DefaultMovementService(movementRepositoryMock.Object, new Mock<IQueryMappingService>().Object);
             var moveService = new DefaultMoveService(movesRepositoryMock.Object, new Mock<IQueryMappingService>().Object);
             var characterAttributeService = new DefaultCharacterAttributeService(characterAttributeRepositoryMock.Object);
             var dtoProvider = new DefaultDtoProvider();

--- a/FrannHammer.WebApi.Specs/Characters/CharacterApi.feature
+++ b/FrannHammer.WebApi.Specs/Characters/CharacterApi.feature
@@ -64,9 +64,9 @@ Scenario Outline: I want all of the gravity movement data for a character
 	Then the result should be a list containing just that characters gravity movement data
 
 Examples: 
-	| apiRoute                                                         | routeParameter |
-	| api/characters/name/{name}/movements/search?movementname=gravity | name Bowser    |
-	| api/characters/{id}/movements/search?movementame=gravity         | id 58          |
+	| apiRoute                                                          | routeParameter |
+	| api/characters/name/{name}/movements/search?movementname=gravity  | name Bowser    |
+	| api/characters/{id}/movements/search?movementname=gravity         | id 58          |
 
 Scenario Outline: I want all the metadata, movement data and attribute data for a specific character in one request
 	Given The api route of <apiRoute>

--- a/FrannHammer.WebApi.Specs/Characters/CharacterApi.feature.cs
+++ b/FrannHammer.WebApi.Specs/Characters/CharacterApi.feature.cs
@@ -179,7 +179,7 @@ this.ScenarioSetup(scenarioInfo);
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("I want all of the gravity movement data for a character")]
         [NUnit.Framework.TestCaseAttribute("api/characters/name/{name}/movements/search?movementname=gravity", "name Bowser", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("api/characters/{id}/movements/search?movementame=gravity", "id 58", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("api/characters/{id}/movements/search?movementname=gravity", "id 58", new string[0])]
         public virtual void IWantAllOfTheGravityMovementDataForACharacter(string apiRoute, string routeParameter, string[] exampleTags)
         {
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("I want all of the gravity movement data for a character", exampleTags);

--- a/FrannHammer.WebApi/Controllers/CharacterController.cs
+++ b/FrannHammer.WebApi/Controllers/CharacterController.cs
@@ -97,6 +97,20 @@ namespace FrannHammer.WebApi.Controllers
             return Result(movements);
         }
 
+        [Route(CharactersRouteKey + NameRouteKey + MovementsRouteKey + SearchRouteKey)]
+        public IHttpActionResult GetAllMovementsForCharacterByNameWhereFilter([FromUri] MovementFilterResourceQuery query)
+        {
+            var movements = _characterService.GetAllMovementsWhereCharacterNameIsFilteredBy(query);
+            return Result(movements);
+        }
+
+        [Route(CharactersRouteKey + IdRouteKey + MovementsRouteKey + SearchRouteKey)]
+        public IHttpActionResult GetAllMovementsForCharacterByOwnerIdWhereFilter([FromUri] MovementFilterResourceQuery query)
+        {
+            var movements = _characterService.GetAllMovementsWhereCharacterOwnerIdIsFilteredBy(query);
+            return Result(movements);
+        }
+
         [Route(CharactersRouteKey + IdRouteKey + MovementsRouteKey)]
         public IHttpActionResult GetAllMovementsForCharacterWhereOwnerId(int id, [FromUri] string fields = "")
         {


### PR DESCRIPTION

- DefaultMovementService ctor now takes an IQueryMappingService instance
- Added a base interface 'IFilterResourceQuery' and 'IMovementFilterResourceQuery' that contains the available parameters consumers can use when searching data