### PR TITLE
- Deprecated support for custom response objects.

### DIFF
--- a/FrannHammer.Api.Services.Contracts/FrannHammer.Api.Services.Contracts.csproj
+++ b/FrannHammer.Api.Services.Contracts/FrannHammer.Api.Services.Contracts.csproj
@@ -47,6 +47,8 @@
     <Compile Include="IDtoProvider.cs" />
     <Compile Include="IMovementService.cs" />
     <Compile Include="IMoveService.cs" />
+    <Compile Include="IReaderService.cs" />
+    <Compile Include="IWriterService.cs" />
     <Compile Include="ParsedMove.cs" />
     <Compile Include="ParsedMoveAttribute.cs" />
     <Compile Include="ParsedMoveDataProperty.cs" />

--- a/FrannHammer.Api.Services.Contracts/ICharacterAttributeRowService.cs
+++ b/FrannHammer.Api.Services.Contracts/ICharacterAttributeRowService.cs
@@ -5,7 +5,7 @@ namespace FrannHammer.Api.Services.Contracts
 {
     public interface ICharacterAttributeRowService : ICrudService<ICharacterAttributeRow>
     {
-        IEnumerable<ICharacterAttributeRow> GetAllWhereCharacterNameIs(string name, string fields = "");
-        IEnumerable<ICharacterAttributeRow> GetAllWhereCharacterOwnerIdIs(int id, string fields = "");
+        IEnumerable<ICharacterAttributeRow> GetAllWhereCharacterNameIs(string name);
+        IEnumerable<ICharacterAttributeRow> GetAllWhereCharacterOwnerIdIs(int id);
     }
 }

--- a/FrannHammer.Api.Services.Contracts/ICharacterService.cs
+++ b/FrannHammer.Api.Services.Contracts/ICharacterService.cs
@@ -5,26 +5,22 @@ namespace FrannHammer.Api.Services.Contracts
 {
     public interface ICharacterService : ICrudService<ICharacter>
     {
-        ICharacter GetSingleByOwnerId(int id, string fields = "");
-        ICharacter GetSingleByName(string name, string fields = "");
-        ICharacterDetailsDto GetCharacterDetailsWhereCharacterOwnerIs(string name, string fields = "");
-        IEnumerable<IMovement> GetAllMovementsWhereCharacterNameIs(string name, string fields = "");
-        IEnumerable<ICharacterAttributeRow> GetAllAttributesWhereCharacterNameIs(string name, string fields = "");
-        IEnumerable<ParsedMove> GetDetailedMovesWhereCharacterNameIs(string name, string fields = "");
-        IEnumerable<IMovement> GetAllMovementsWhereCharacterOwnerIdIs(int id, string fields = "");
-        ICharacterDetailsDto GetCharacterDetailsWhereCharacterOwnerIdIs(int id, string fields);
-        IEnumerable<ICharacterAttributeRow> GetAllAttributesWhereCharacterOwnerIdIs(int id, string fields = "");
-        IEnumerable<ParsedMove> GetDetailedMovesWhereCharacterOwnerIdIs(int id, string fields = "");
-
-        IEnumerable<IMove> GetAllThrowsWhereCharacterOwnerIdIs(int id, string fields = "");
-        IEnumerable<IMove> GetAllThrowsWhereCharacterNameIs(string name, string fields = "");
-
-        IEnumerable<IMove> GetAllMovesWhereCharacterOwnerIdIs(int id, string fields = "");
-        IEnumerable<IMove> GetAllMovesWhereCharacterNameIs(string name, string fields = "");
-
+        ICharacter GetSingleByOwnerId(int id);
+        ICharacter GetSingleByName(string name);
+        ICharacterDetailsDto GetCharacterDetailsWhereCharacterOwnerIs(string name);
+        IEnumerable<IMovement> GetAllMovementsWhereCharacterNameIs(string name);
+        IEnumerable<ICharacterAttributeRow> GetAllAttributesWhereCharacterNameIs(string name);
+        IEnumerable<ParsedMove> GetDetailedMovesWhereCharacterNameIs(string name);
+        IEnumerable<IMovement> GetAllMovementsWhereCharacterOwnerIdIs(int id);
+        ICharacterDetailsDto GetCharacterDetailsWhereCharacterOwnerIdIs(int id);
+        IEnumerable<ICharacterAttributeRow> GetAllAttributesWhereCharacterOwnerIdIs(int id);
+        IEnumerable<ParsedMove> GetDetailedMovesWhereCharacterOwnerIdIs(int id);
+        IEnumerable<IMove> GetAllThrowsWhereCharacterOwnerIdIs(int id);
+        IEnumerable<IMove> GetAllThrowsWhereCharacterNameIs(string name);
+        IEnumerable<IMove> GetAllMovesWhereCharacterOwnerIdIs(int id);
+        IEnumerable<IMove> GetAllMovesWhereCharacterNameIs(string name);
         IEnumerable<IMove> GetAllMovesForCharacterByNameFilteredBy(IMoveFilterResourceQuery query);
         IEnumerable<IMove> GetAllMovesForCharacterByOwnerIdFilteredBy(IMoveFilterResourceQuery query);
-
         IEnumerable<IMovement> GetAllMovementsWhereCharacterOwnerIdIsFilteredBy(IMovementFilterResourceQuery query);
         IEnumerable<IMovement> GetAllMovementsWhereCharacterNameIsFilteredBy(IMovementFilterResourceQuery query);
     }

--- a/FrannHammer.Api.Services.Contracts/ICrudService.cs
+++ b/FrannHammer.Api.Services.Contracts/ICrudService.cs
@@ -1,27 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using FrannHammer.Domain.Contracts;
+﻿using FrannHammer.Domain.Contracts;
 
 namespace FrannHammer.Api.Services.Contracts
 {
     public interface ICrudService<T> : IWriterService<T>, IReaderService<T>
         where T : IModel
     { }
-
-    public interface IWriterService<in T>
-        where T : IModel
-    {
-        void Add(T character);
-        void AddMany(IEnumerable<T> models);
-    }
-
-    public interface IReaderService<out T>
-        where T : IModel
-    {
-        T GetSingleWhere(Func<T, bool> where, string fields = "");
-        IEnumerable<T> GetAllWhere(Func<T, bool> where, string fields = "");
-        IEnumerable<T> GetAll(string fields = "");
-        T GetSingleByInstanceId(string id, string fields = "");
-        IEnumerable<T> GetAllWhereName(string name, string fields = "");
-    }
 }

--- a/FrannHammer.Api.Services.Contracts/IMoveService.cs
+++ b/FrannHammer.Api.Services.Contracts/IMoveService.cs
@@ -5,17 +5,15 @@ namespace FrannHammer.Api.Services.Contracts
 {
     public interface IMoveService : ICrudService<IMove>
     {
-        IEnumerable<IDictionary<string, string>> GetAllPropertyDataWhereName(string name, string property,
-            string fields = "");
-
-        IDictionary<string, string> GetPropertyDataWhereId(string id, string property, string fields = "");
-        IEnumerable<IMove> GetAllThrowsWhereCharacterNameIs(string name, string fields = "");
-        IEnumerable<IMove> GetAllWhereCharacterNameIs(string name, string fields = "");
-        IEnumerable<IMove> GetAllWhere(IMoveFilterResourceQuery query, string fields = "");
-        IEnumerable<ParsedMove> GetAllMovePropertyDataForCharacter(ICharacter character, string fields = "");
-        IEnumerable<IMove> GetAllThrowsWhereCharacterOwnerIdIs(int ownerId, string fields = "");
-        IEnumerable<IMove> GetAllWhereCharacterOwnerIdIs(int id, string fields = "");
-        IEnumerable<IMove> GetAllThrowsForCharacter(ICharacter character, string fields = "");
-        IEnumerable<IMove> GetAllMovesForCharacter(ICharacter character, string fields = "");
+        IEnumerable<IDictionary<string, string>> GetAllPropertyDataWhereName(string name, string property);
+        IDictionary<string, string> GetPropertyDataWhereId(string id, string property);
+        IEnumerable<IMove> GetAllThrowsWhereCharacterNameIs(string name);
+        IEnumerable<IMove> GetAllWhereCharacterNameIs(string name);
+        IEnumerable<IMove> GetAllWhere(IMoveFilterResourceQuery query);
+        IEnumerable<ParsedMove> GetAllMovePropertyDataForCharacter(ICharacter character);
+        IEnumerable<IMove> GetAllThrowsWhereCharacterOwnerIdIs(int ownerId);
+        IEnumerable<IMove> GetAllWhereCharacterOwnerIdIs(int id);
+        IEnumerable<IMove> GetAllThrowsForCharacter(ICharacter character);
+        IEnumerable<IMove> GetAllMovesForCharacter(ICharacter character);
     }
 }

--- a/FrannHammer.Api.Services.Contracts/IMovementService.cs
+++ b/FrannHammer.Api.Services.Contracts/IMovementService.cs
@@ -5,8 +5,8 @@ namespace FrannHammer.Api.Services.Contracts
 {
     public interface IMovementService : ICrudService<IMovement>
     {
-        IEnumerable<IMovement> GetAllWhereCharacterNameIs(string name, string fields = "");
-        IEnumerable<IMovement> GetAllWhereCharacterOwnerIdIs(int id, string fields = "");
-        IEnumerable<IMovement> GetAllWhere(IFilterResourceQuery query, string fields = "");
+        IEnumerable<IMovement> GetAllWhereCharacterNameIs(string name);
+        IEnumerable<IMovement> GetAllWhereCharacterOwnerIdIs(int id);
+        IEnumerable<IMovement> GetAllWhere(IFilterResourceQuery query);
     }
 }

--- a/FrannHammer.Api.Services.Contracts/IReaderService.cs
+++ b/FrannHammer.Api.Services.Contracts/IReaderService.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using FrannHammer.Domain.Contracts;
+
+namespace FrannHammer.Api.Services.Contracts
+{
+    public interface IReaderService<out T>
+        where T : IModel
+    {
+        T GetSingleWhere(Func<T, bool> where);
+        IEnumerable<T> GetAllWhere(Func<T, bool> where);
+        IEnumerable<T> GetAll();
+        T GetSingleByInstanceId(string id);
+        IEnumerable<T> GetAllWhereName(string name);
+    }
+}

--- a/FrannHammer.Api.Services.Contracts/IWriterService.cs
+++ b/FrannHammer.Api.Services.Contracts/IWriterService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using FrannHammer.Domain.Contracts;
+
+namespace FrannHammer.Api.Services.Contracts
+{
+    public interface IWriterService<in T>
+        where T : IModel
+    {
+        void Add(T character);
+        void AddMany(IEnumerable<T> models);
+    }
+}

--- a/FrannHammer.Api.Services/BaseApiService.cs
+++ b/FrannHammer.Api.Services/BaseApiService.cs
@@ -18,17 +18,17 @@ namespace FrannHammer.Api.Services
             Repository = repository;
         }
 
-        public T GetSingleByInstanceId(string id, string fields = "")
+        public T GetSingleByInstanceId(string id)
         {
-            return GetSingleWhere(m => m.InstanceId == id, fields);
+            return GetSingleWhere(m => m.InstanceId == id);
         }
 
-        public IEnumerable<T> GetAllWhereName(string name, string fields = "")
+        public IEnumerable<T> GetAllWhereName(string name)
         {
-            return GetAllWhere(m => m.Name.Equals(name, StringComparison.OrdinalIgnoreCase), fields);
+            return GetAllWhere(m => m.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
         }
 
-        public IEnumerable<T> GetAll(string fields = "")
+        public IEnumerable<T> GetAll()
         {
             return Repository.GetAll();
         }
@@ -45,13 +45,13 @@ namespace FrannHammer.Api.Services
             Repository.AddMany(moves);
         }
 
-        public T GetSingleWhere(Func<T, bool> @where, string fields = "")
+        public T GetSingleWhere(Func<T, bool> @where)
         {
             var move = Repository.GetSingleWhere(where);
             return move;
         }
 
-        public IEnumerable<T> GetAllWhere(Func<T, bool> @where, string fields = "")
+        public IEnumerable<T> GetAllWhere(Func<T, bool> @where)
         {
             var moves = Repository.GetAllWhere(where);
             return moves;

--- a/FrannHammer.Api.Services/DefaultCharacterAttributeService.cs
+++ b/FrannHammer.Api.Services/DefaultCharacterAttributeService.cs
@@ -13,7 +13,7 @@ namespace FrannHammer.Api.Services
             : base(characterAttributeRowRepository)
         { }
 
-        public override IEnumerable<ICharacterAttributeRow> GetAllWhereCharacterNameIs(string name, string fields = "")
+        public override IEnumerable<ICharacterAttributeRow> GetAllWhereCharacterNameIs(string name)
         {
             Guard.VerifyStringIsNotNullOrEmpty(name, nameof(name));
             return GetAllWhere(item => item.Owner.Equals(name, StringComparison.OrdinalIgnoreCase));

--- a/FrannHammer.Api.Services/DefaultCharacterService.cs
+++ b/FrannHammer.Api.Services/DefaultCharacterService.cs
@@ -30,12 +30,12 @@ namespace FrannHammer.Api.Services
             _movementService = movementService;
         }
 
-        public ICharacter GetSingleByOwnerId(int id, string fields = "")
+        public ICharacter GetSingleByOwnerId(int id)
         {
             return Repository.GetSingleWhere(c => c.OwnerId == id);
         }
 
-        public ICharacter GetSingleByName(string name, string fields = "")
+        public ICharacter GetSingleByName(string name)
         {
             var character = Repository.GetSingleWhere(c => c.Name.Equals(name, StringComparison.CurrentCultureIgnoreCase));
             if (character == null)
@@ -45,15 +45,15 @@ namespace FrannHammer.Api.Services
             return character;
         }
 
-        public ICharacterDetailsDto GetCharacterDetailsWhereCharacterOwnerIs(string name, string fields = "")
+        public ICharacterDetailsDto GetCharacterDetailsWhereCharacterOwnerIs(string name)
         {
             var character = GetSingleWhere(c => c.Name.Equals(name, StringComparison.CurrentCultureIgnoreCase));
 
             //get movement, attributes and put into aggregate dto 
             var dto = _dtoProvider.CreateCharacterDetailsDto();
 
-            var movements = _movementService.GetAllWhereCharacterNameIs(name, fields);
-            var attributeRows = _attributeRowService.GetAllWhereCharacterNameIs(name, fields);
+            var movements = _movementService.GetAllWhereCharacterNameIs(name);
+            var attributeRows = _attributeRowService.GetAllWhereCharacterNameIs(name);
 
             dto.Metadata = character;
             dto.Movements = movements;
@@ -62,14 +62,14 @@ namespace FrannHammer.Api.Services
             return dto;
         }
 
-        public ICharacterDetailsDto GetCharacterDetailsWhereCharacterOwnerIdIs(int id, string fields)
+        public ICharacterDetailsDto GetCharacterDetailsWhereCharacterOwnerIdIs(int id)
         {
             var character = GetSingleWhere(c => c.OwnerId == id);
 
             var dto = _dtoProvider.CreateCharacterDetailsDto();
 
-            var movements = _movementService.GetAllWhereCharacterOwnerIdIs(id, fields);
-            var attributeRows = _attributeRowService.GetAllWhereCharacterOwnerIdIs(id, fields);
+            var movements = _movementService.GetAllWhereCharacterOwnerIdIs(id);
+            var attributeRows = _attributeRowService.GetAllWhereCharacterOwnerIdIs(id);
 
             dto.Metadata = character;
             dto.Movements = movements;
@@ -78,35 +78,35 @@ namespace FrannHammer.Api.Services
             return dto;
         }
 
-        public IEnumerable<IMovement> GetAllMovementsWhereCharacterNameIs(string name, string fields = "")
+        public IEnumerable<IMovement> GetAllMovementsWhereCharacterNameIs(string name)
         {
-            return _movementService.GetAllWhereCharacterNameIs(name, fields);
+            return _movementService.GetAllWhereCharacterNameIs(name);
         }
 
-        public IEnumerable<IMovement> GetAllMovementsWhereCharacterOwnerIdIs(int id, string fields = "")
+        public IEnumerable<IMovement> GetAllMovementsWhereCharacterOwnerIdIs(int id)
         {
-            return _movementService.GetAllWhereCharacterOwnerIdIs(id, fields);
+            return _movementService.GetAllWhereCharacterOwnerIdIs(id);
         }
 
-        public IEnumerable<ICharacterAttributeRow> GetAllAttributesWhereCharacterNameIs(string name, string fields = "")
+        public IEnumerable<ICharacterAttributeRow> GetAllAttributesWhereCharacterNameIs(string name)
         {
-            return _attributeRowService.GetAllWhereCharacterNameIs(name, fields);
+            return _attributeRowService.GetAllWhereCharacterNameIs(name);
         }
 
-        public IEnumerable<ICharacterAttributeRow> GetAllAttributesWhereCharacterOwnerIdIs(int id, string fields = "")
+        public IEnumerable<ICharacterAttributeRow> GetAllAttributesWhereCharacterOwnerIdIs(int id)
         {
-            return _attributeRowService.GetAllWhereCharacterOwnerIdIs(id, fields);
+            return _attributeRowService.GetAllWhereCharacterOwnerIdIs(id);
         }
 
-        public IEnumerable<ParsedMove> GetDetailedMovesWhereCharacterNameIs(string name, string fields = "")
+        public IEnumerable<ParsedMove> GetDetailedMovesWhereCharacterNameIs(string name)
         {
-            var foundCharacter = GetSingleByName(name, fields);
+            var foundCharacter = GetSingleByName(name);
             return GetDetailedMovesCore(foundCharacter);
         }
 
-        public IEnumerable<ParsedMove> GetDetailedMovesWhereCharacterOwnerIdIs(int id, string fields = "")
+        public IEnumerable<ParsedMove> GetDetailedMovesWhereCharacterOwnerIdIs(int id)
         {
-            var foundCharacter = GetSingleByOwnerId(id, fields);
+            var foundCharacter = GetSingleByOwnerId(id);
             return GetDetailedMovesCore(foundCharacter);
         }
 
@@ -115,28 +115,28 @@ namespace FrannHammer.Api.Services
             return _moveService.GetAllMovePropertyDataForCharacter(character);
         }
 
-        public IEnumerable<IMove> GetAllThrowsWhereCharacterNameIs(string name, string fields = "")
+        public IEnumerable<IMove> GetAllThrowsWhereCharacterNameIs(string name)
         {
-            var foundCharacter = GetSingleByName(name, fields);
-            return _moveService.GetAllThrowsForCharacter(foundCharacter, fields);
+            var foundCharacter = GetSingleByName(name);
+            return _moveService.GetAllThrowsForCharacter(foundCharacter);
         }
 
-        public IEnumerable<IMove> GetAllMovesWhereCharacterNameIs(string name, string fields = "")
+        public IEnumerable<IMove> GetAllMovesWhereCharacterNameIs(string name)
         {
-            var foundCharacter = GetSingleByName(name, fields);
-            return _moveService.GetAllMovesForCharacter(foundCharacter, fields);
+            var foundCharacter = GetSingleByName(name);
+            return _moveService.GetAllMovesForCharacter(foundCharacter);
         }
 
-        public IEnumerable<IMove> GetAllThrowsWhereCharacterOwnerIdIs(int id, string fields = "")
+        public IEnumerable<IMove> GetAllThrowsWhereCharacterOwnerIdIs(int id)
         {
-            var foundCharacter = GetSingleByOwnerId(id, fields);
-            return _moveService.GetAllThrowsForCharacter(foundCharacter, fields);
+            var foundCharacter = GetSingleByOwnerId(id);
+            return _moveService.GetAllThrowsForCharacter(foundCharacter);
         }
 
-        public IEnumerable<IMove> GetAllMovesWhereCharacterOwnerIdIs(int id, string fields = "")
+        public IEnumerable<IMove> GetAllMovesWhereCharacterOwnerIdIs(int id)
         {
-            var foundCharacter = GetSingleByOwnerId(id, fields);
-            return _moveService.GetAllMovesForCharacter(foundCharacter, fields);
+            var foundCharacter = GetSingleByOwnerId(id);
+            return _moveService.GetAllMovesForCharacter(foundCharacter);
         }
 
         public IEnumerable<IMove> GetAllMovesForCharacterByNameFilteredBy(IMoveFilterResourceQuery query)

--- a/FrannHammer.Api.Services/DefaultMoveService.cs
+++ b/FrannHammer.Api.Services/DefaultMoveService.cs
@@ -25,7 +25,7 @@ namespace FrannHammer.Api.Services
             _queryMappingService = queryMappingService;
         }
 
-        public IEnumerable<IDictionary<string, string>> GetAllPropertyDataWhereName(string name, string property, string fields = "")
+        public IEnumerable<IDictionary<string, string>> GetAllPropertyDataWhereName(string name, string property)
         {
             Guard.VerifyStringIsNotNullOrEmpty(name, nameof(name));
             Guard.VerifyStringIsNotNullOrEmpty(property, nameof(property));
@@ -76,7 +76,7 @@ namespace FrannHammer.Api.Services
             return strongTypedPropertyInEachMove;
         }
 
-        public IEnumerable<ParsedMove> GetAllMovePropertyDataForCharacter(ICharacter character, string fields = "")
+        public IEnumerable<ParsedMove> GetAllMovePropertyDataForCharacter(ICharacter character)
         {
             var allMovesForCharacter = GetAllWhere(move => move.OwnerId == character.OwnerId).ToList();
 
@@ -151,7 +151,7 @@ namespace FrannHammer.Api.Services
             }
         }
 
-        public IDictionary<string, string> GetPropertyDataWhereId(string id, string property, string fields = "")
+        public IDictionary<string, string> GetPropertyDataWhereId(string id, string property)
         {
             Guard.VerifyStringIsNotNullOrEmpty(id, nameof(id));
             Guard.VerifyStringIsNotNullOrEmpty(property, nameof(property));
@@ -230,7 +230,7 @@ namespace FrannHammer.Api.Services
             return parserType;
         }
 
-        public IEnumerable<IMove> GetAllThrowsWhereCharacterNameIs(string name, string fields = "")
+        public IEnumerable<IMove> GetAllThrowsWhereCharacterNameIs(string name)
         {
             Guard.VerifyStringIsNotNullOrEmpty(name, nameof(name));
 
@@ -240,7 +240,7 @@ namespace FrannHammer.Api.Services
             return throwMoves;
         }
 
-        public IEnumerable<IMove> GetAllThrowsWhereCharacterOwnerIdIs(int ownerId, string fields = "")
+        public IEnumerable<IMove> GetAllThrowsWhereCharacterOwnerIdIs(int ownerId)
         {
             var throwMoves = GetAllWhere(move => move.OwnerId == ownerId &&
                                                  move.MoveType == MoveType.Throw.GetEnumDescription());
@@ -248,14 +248,14 @@ namespace FrannHammer.Api.Services
             return throwMoves;
         }
 
-        public IEnumerable<IMove> GetAllWhere(IMoveFilterResourceQuery query, string fields = "")
+        public IEnumerable<IMove> GetAllWhere(IMoveFilterResourceQuery query)
         {
             var queryFilterParameters = _queryMappingService.MapResourceQueryToDictionary(query, BindingFlags.Public | BindingFlags.Instance);
 
             return GetAllWhere(queryFilterParameters);
         }
 
-        public IEnumerable<IMove> GetAllThrowsForCharacter(ICharacter character, string fields = "")
+        public IEnumerable<IMove> GetAllThrowsForCharacter(ICharacter character)
         {
             Guard.VerifyObjectNotNull(character, nameof(character));
             Guard.VerifyStringIsNotNullOrEmpty(character.Name, nameof(character.Name));
@@ -266,7 +266,7 @@ namespace FrannHammer.Api.Services
             return throwMoves;
         }
 
-        public IEnumerable<IMove> GetAllMovesForCharacter(ICharacter character, string fields = "")
+        public IEnumerable<IMove> GetAllMovesForCharacter(ICharacter character)
         {
             var moves = GetAllWhere(move => move.OwnerId == character.OwnerId);
             return moves;

--- a/FrannHammer.Api.Services/DefaultMovementService.cs
+++ b/FrannHammer.Api.Services/DefaultMovementService.cs
@@ -18,7 +18,7 @@ namespace FrannHammer.Api.Services
             _queryMappingService = queryMappingService;
         }
 
-        public IEnumerable<IMovement> GetAllWhere(IFilterResourceQuery query, string fields = "")
+        public IEnumerable<IMovement> GetAllWhere(IFilterResourceQuery query)
         {
             var queryFilterParameters = _queryMappingService.MapResourceQueryToDictionary(query,
                 BindingFlags.Public | BindingFlags.Instance);

--- a/FrannHammer.Api.Services/OwnerBasedApiService.cs
+++ b/FrannHammer.Api.Services/OwnerBasedApiService.cs
@@ -12,13 +12,13 @@ namespace FrannHammer.Api.Services
             : base(repository)
         { }
 
-        public virtual IEnumerable<T> GetAllWhereCharacterNameIs(string name, string fields = "")
+        public virtual IEnumerable<T> GetAllWhereCharacterNameIs(string name)
         {
             Guard.VerifyStringIsNotNullOrEmpty(name, nameof(name));
             return GetAllWhere(item => item.Owner.Equals(name));
         }
 
-        public virtual IEnumerable<T> GetAllWhereCharacterOwnerIdIs(int id, string fields = "")
+        public virtual IEnumerable<T> GetAllWhereCharacterOwnerIdIs(int id)
         {
             return GetAllWhere(item => item.OwnerId == id);
         }

--- a/FrannHammer.WebApi/Controllers/CharacterAttributeController.cs
+++ b/FrannHammer.WebApi/Controllers/CharacterAttributeController.cs
@@ -18,23 +18,23 @@ namespace FrannHammer.WebApi.Controllers
         }
 
         [Route(CharacterAttributesRouteKey, Name = nameof(GetAllCharacterAttributes))]
-        public IHttpActionResult GetAllCharacterAttributes([FromUri] string fields = "")
+        public IHttpActionResult GetAllCharacterAttributes()
         {
-            var content = _characterAttributeRowService.GetAll(fields);
+            var content = _characterAttributeRowService.GetAll();
             return Result(content);
         }
 
         [Route(CharacterAttributesRouteKey + "/{id}", Name = nameof(GetCharacterAttributeById))]
-        public IHttpActionResult GetCharacterAttributeById(string id, [FromUri] string fields = "")
+        public IHttpActionResult GetCharacterAttributeById(string id)
         {
-            var content = _characterAttributeRowService.GetSingleByInstanceId(id, fields);
+            var content = _characterAttributeRowService.GetSingleByInstanceId(id);
             return Result(content);
         }
 
         [Route(CharacterAttributesRouteKey + "/name/{name}", Name = nameof(GetSingleCharacterAttributeByName))]
-        public IHttpActionResult GetSingleCharacterAttributeByName(string name, string fields = "")
+        public IHttpActionResult GetSingleCharacterAttributeByName(string name)
         {
-            var content = _characterAttributeRowService.GetAllWhereName(name, fields);
+            var content = _characterAttributeRowService.GetAllWhereName(name);
             return Result(content);
         }
     }

--- a/FrannHammer.WebApi/Controllers/CharacterController.cs
+++ b/FrannHammer.WebApi/Controllers/CharacterController.cs
@@ -28,37 +28,37 @@ namespace FrannHammer.WebApi.Controllers
         }
 
         [Route(CharactersRouteKey + IdRouteKey, Name = nameof(GetCharacterByOwnerId))]
-        public IHttpActionResult GetCharacterByOwnerId(int id, [FromUri]string fields = "")
+        public IHttpActionResult GetCharacterByOwnerId(int id)
         {
-            var character = _characterService.GetSingleByOwnerId(id, fields);
+            var character = _characterService.GetSingleByOwnerId(id);
             return Result(character);
         }
 
         [Route(CharactersRouteKey + NameRouteKey, Name = nameof(GetSingleCharacterByName))]
-        public IHttpActionResult GetSingleCharacterByName(string name, [FromUri]string fields = "")
+        public IHttpActionResult GetSingleCharacterByName(string name)
         {
-            var character = _characterService.GetSingleByName(name, fields);
+            var character = _characterService.GetSingleByName(name);
             return Result(character);
         }
 
         [Route(CharactersRouteKey, Name = nameof(GetAllCharacters))]
-        public IHttpActionResult GetAllCharacters([FromUri]string fields = "")
+        public IHttpActionResult GetAllCharacters()
         {
-            var characters = _characterService.GetAll(fields);
+            var characters = _characterService.GetAll();
             return Result(characters);
         }
 
         [Route(CharactersRouteKey + NameRouteKey + ThrowsRouteKey, Name = nameof(GetAllThrowsForCharacterWhereName))]
-        public IHttpActionResult GetAllThrowsForCharacterWhereName(string name, [FromUri]string fields = "")
+        public IHttpActionResult GetAllThrowsForCharacterWhereName(string name)
         {
-            var throws = _characterService.GetAllThrowsWhereCharacterNameIs(name, fields);
+            var throws = _characterService.GetAllThrowsWhereCharacterNameIs(name);
             return Result(throws);
         }
 
         [Route(CharactersRouteKey + IdRouteKey + ThrowsRouteKey, Name = nameof(GetAllThrowsForCharacterWhereOwnerId))]
-        public IHttpActionResult GetAllThrowsForCharacterWhereOwnerId(int id, [FromUri] string fields = "")
+        public IHttpActionResult GetAllThrowsForCharacterWhereOwnerId(int id)
         {
-            var throws = _characterService.GetAllThrowsWhereCharacterOwnerIdIs(id, fields);
+            var throws = _characterService.GetAllThrowsWhereCharacterOwnerIdIs(id);
             return Result(throws);
         }
 
@@ -77,23 +77,23 @@ namespace FrannHammer.WebApi.Controllers
         }
 
         [Route(CharactersRouteKey + NameRouteKey + MovesRouteKey, Name = nameof(GetAllMovesForCharacterWhereName))]
-        public IHttpActionResult GetAllMovesForCharacterWhereName(string name, [FromUri] string fields = "")
+        public IHttpActionResult GetAllMovesForCharacterWhereName(string name)
         {
-            var moves = _characterService.GetAllMovesWhereCharacterNameIs(name, fields);
+            var moves = _characterService.GetAllMovesWhereCharacterNameIs(name);
             return Result(moves);
         }
 
         [Route(CharactersRouteKey + IdRouteKey + MovesRouteKey, Name = nameof(GetAllMovesForCharacterWhereOwnerId))]
-        public IHttpActionResult GetAllMovesForCharacterWhereOwnerId(int id, [FromUri] string fields = "")
+        public IHttpActionResult GetAllMovesForCharacterWhereOwnerId(int id)
         {
-            var moves = _characterService.GetAllMovesWhereCharacterOwnerIdIs(id, fields);
+            var moves = _characterService.GetAllMovesWhereCharacterOwnerIdIs(id);
             return Result(moves);
         }
 
         [Route(CharactersRouteKey + NameRouteKey + MovementsRouteKey, Name = nameof(GetAllMovementsForCharacterWhereName))]
-        public IHttpActionResult GetAllMovementsForCharacterWhereName(string name, [FromUri] string fields = "")
+        public IHttpActionResult GetAllMovementsForCharacterWhereName(string name)
         {
-            var movements = _characterService.GetAllMovementsWhereCharacterNameIs(name, fields);
+            var movements = _characterService.GetAllMovementsWhereCharacterNameIs(name);
             return Result(movements);
         }
 
@@ -112,51 +112,51 @@ namespace FrannHammer.WebApi.Controllers
         }
 
         [Route(CharactersRouteKey + IdRouteKey + MovementsRouteKey, Name = nameof(GetAllMovementsForCharacterWhereOwnerId))]
-        public IHttpActionResult GetAllMovementsForCharacterWhereOwnerId(int id, [FromUri] string fields = "")
+        public IHttpActionResult GetAllMovementsForCharacterWhereOwnerId(int id)
         {
-            var movements = _characterService.GetAllMovementsWhereCharacterOwnerIdIs(id, fields);
+            var movements = _characterService.GetAllMovementsWhereCharacterOwnerIdIs(id);
             return Result(movements);
         }
 
         [Route(CharactersRouteKey + NameRouteKey + DetailsRouteKey, Name = nameof(GetDetailsForCharacterByName))]
-        public IHttpActionResult GetDetailsForCharacterByName(string name, [FromUri] string fields = "")
+        public IHttpActionResult GetDetailsForCharacterByName(string name)
         {
-            var dto = _characterService.GetCharacterDetailsWhereCharacterOwnerIs(name, fields);
+            var dto = _characterService.GetCharacterDetailsWhereCharacterOwnerIs(name);
             return Result(dto);
         }
 
         [Route(CharactersRouteKey + IdRouteKey + DetailsRouteKey, Name = nameof(GetDetailsForCharacterByOwnerId))]
-        public IHttpActionResult GetDetailsForCharacterByOwnerId(int id, [FromUri] string fields = "")
+        public IHttpActionResult GetDetailsForCharacterByOwnerId(int id)
         {
-            var dto = _characterService.GetCharacterDetailsWhereCharacterOwnerIdIs(id, fields);
+            var dto = _characterService.GetCharacterDetailsWhereCharacterOwnerIdIs(id);
             return Result(dto);
         }
 
         [Route(CharactersRouteKey + NameRouteKey + CharacterAttributesRouteKey, Name = nameof(GetAttributesForCharacterByName))]
-        public IHttpActionResult GetAttributesForCharacterByName(string name, [FromUri] string fields = "")
+        public IHttpActionResult GetAttributesForCharacterByName(string name)
         {
-            var attributeRows = _characterService.GetAllAttributesWhereCharacterNameIs(name, fields);
+            var attributeRows = _characterService.GetAllAttributesWhereCharacterNameIs(name);
             return Result(attributeRows);
         }
 
         [Route(CharactersRouteKey + IdRouteKey + CharacterAttributesRouteKey, Name = nameof(GetAttributesForCharacterByOwnerId))]
-        public IHttpActionResult GetAttributesForCharacterByOwnerId(int id, [FromUri] string fields = "")
+        public IHttpActionResult GetAttributesForCharacterByOwnerId(int id)
         {
-            var attributeRows = _characterService.GetAllAttributesWhereCharacterOwnerIdIs(id, fields);
+            var attributeRows = _characterService.GetAllAttributesWhereCharacterOwnerIdIs(id);
             return Result(attributeRows);
         }
 
         [Route(CharactersRouteKey + NameRouteKey + DetailedMovesRouteKey, Name = nameof(GetDetailedMovesForCharacterByName))]
-        public IHttpActionResult GetDetailedMovesForCharacterByName(string name, [FromUri] string fields = "")
+        public IHttpActionResult GetDetailedMovesForCharacterByName(string name)
         {
-            var detailedMoves = _characterService.GetDetailedMovesWhereCharacterNameIs(name, fields);
+            var detailedMoves = _characterService.GetDetailedMovesWhereCharacterNameIs(name);
             return Result(detailedMoves);
         }
 
         [Route(CharactersRouteKey + IdRouteKey + DetailedMovesRouteKey, Name = nameof(GetDetailedMovesForCharacterByOwnerId))]
-        public IHttpActionResult GetDetailedMovesForCharacterByOwnerId(int id, [FromUri] string fields = "")
+        public IHttpActionResult GetDetailedMovesForCharacterByOwnerId(int id)
         {
-            var detailedMoves = _characterService.GetDetailedMovesWhereCharacterOwnerIdIs(id, fields);
+            var detailedMoves = _characterService.GetDetailedMovesWhereCharacterOwnerIdIs(id);
             return Result(detailedMoves);
         }
     }

--- a/FrannHammer.WebApi/Controllers/MoveController.cs
+++ b/FrannHammer.WebApi/Controllers/MoveController.cs
@@ -18,37 +18,37 @@ namespace FrannHammer.WebApi.Controllers
         }
 
         [Route(MovesRouteKey + "/{id}", Name = nameof(GetMoveById))]
-        public IHttpActionResult GetMoveById(string id, [FromUri]string fields = "")
+        public IHttpActionResult GetMoveById(string id)
         {
-            var move = _moveService.GetSingleByInstanceId(id, fields);
+            var move = _moveService.GetSingleByInstanceId(id);
             return Result(move);
         }
 
         [Route(MovesRouteKey, Name = nameof(GetAllMoves))]
-        public IHttpActionResult GetAllMoves([FromUri]string fields = "")
+        public IHttpActionResult GetAllMoves()
         {
-            var moves = _moveService.GetAll(fields);
+            var moves = _moveService.GetAll();
             return Result(moves);
         }
 
         [Route(MovesRouteKey + "/name/{name}", Name = nameof(GetSingleMoveByName))]
-        public IHttpActionResult GetSingleMoveByName(string name, string fields = "")
+        public IHttpActionResult GetSingleMoveByName(string name)
         {
-            var content = _moveService.GetAllWhereName(name, fields);
+            var content = _moveService.GetAllWhereName(name);
             return Result(content);
         }
 
         [Route(MovesRouteKey + "/name/{name}/{property}", Name = nameof(GetAllPropertyDataForMoveByName))]
-        public IHttpActionResult GetAllPropertyDataForMoveByName(string name, string property, string fields = "")
+        public IHttpActionResult GetAllPropertyDataForMoveByName(string name, string property)
         {
-            var content = _moveService.GetAllPropertyDataWhereName(name, property, fields);
+            var content = _moveService.GetAllPropertyDataWhereName(name, property);
             return Result(content);
         }
 
         [Route(MovesRouteKey + "/{id}/{property}", Name = nameof(GetAllPropertyDataForMoveById))]
-        public IHttpActionResult GetAllPropertyDataForMoveById(string id, string property, string fields = "")
+        public IHttpActionResult GetAllPropertyDataForMoveById(string id, string property)
         {
-            var content = _moveService.GetPropertyDataWhereId(id, property, fields);
+            var content = _moveService.GetPropertyDataWhereId(id, property);
             return Result(content);
         }
     }

--- a/FrannHammer.WebApi/Controllers/MovementController.cs
+++ b/FrannHammer.WebApi/Controllers/MovementController.cs
@@ -21,12 +21,10 @@ namespace FrannHammer.WebApi.Controllers
         /// <summary>
         /// Get all movement data.
         /// </summary>
-        /// <param name="fields">Specify which specific pieces of the response model you need via comma-separated values. <para> 
-        /// E.g., id,name to get back just the id and name.</para></param>
         [Route(MovementsRouteKey, Name = nameof(GetAllMovements))]
-        public IHttpActionResult GetAllMovements([FromUri] string fields = "")
+        public IHttpActionResult GetAllMovements()
         {
-            var content = _movementService.GetAll(fields);
+            var content = _movementService.GetAll();
             return Result(content);
         }
 
@@ -34,19 +32,17 @@ namespace FrannHammer.WebApi.Controllers
         /// Get a specific <see cref="IMovement"/>.
         /// </summary>
         /// <param name="id"></param>
-        /// <param name="fields">Specify which specific pieces of the response model you need via comma-separated values. <para> 
-        /// E.g., id,name to get back just the id and name.</para></param>
         [Route(MovementsRouteKey + "/{id}", Name = nameof(GetMovementById))]
-        public IHttpActionResult GetMovementById(string id, [FromUri] string fields = "")
+        public IHttpActionResult GetMovementById(string id)
         {
-            var content = _movementService.GetSingleByInstanceId(id, fields);
+            var content = _movementService.GetSingleByInstanceId(id);
             return Result(content);
         }
 
         [Route(MovementsRouteKey + "/name/{name}", Name = nameof(GetSingleMovementByName))]
-        public IHttpActionResult GetSingleMovementByName(string name, string fields = "")
+        public IHttpActionResult GetSingleMovementByName(string name)
         {
-            var content = _movementService.GetAllWhereName(name, fields);
+            var content = _movementService.GetAllWhereName(name);
             return Result(content);
         }
     }

--- a/FrannHammer.WebApi/FrannHammer.WebApi.csproj
+++ b/FrannHammer.WebApi/FrannHammer.WebApi.csproj
@@ -36,7 +36,8 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>App_Data/XmlDocument.xml</DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
- Separated Crud API services into their own files.

It doesn't seem like the custom response object features are being used by anyone and they require a sizable change to implement against MongoDb.  

If there is high demand I'll consider adding them back in.