### PR TITLE
Fixes 234

### DIFF
--- a/src/Implementation/FrannHammer.WebScraping/Moves/BaseMoveScraper.cs
+++ b/src/Implementation/FrannHammer.WebScraping/Moves/BaseMoveScraper.cs
@@ -24,7 +24,7 @@ namespace FrannHammer.WebScraping.Moves
 
         protected static HtmlNodeCollection GetTableCells(HtmlNode row) => row.SelectNodes(ScrapingConstants.XPathTableCells);
 
-        protected virtual HtmlNodeCollection GetTableRows(string sourceUrl, string xpath)
+        protected virtual IEnumerable<HtmlNode> GetTableRows(string sourceUrl, string xpath)
         {
             var htmlParser = ScrapingServices.CreateParserFromSourceUrl(sourceUrl);
 

--- a/src/Implementation/FrannHammer.WebScraping/Moves/GroundMoveScraper.cs
+++ b/src/Implementation/FrannHammer.WebScraping/Moves/GroundMoveScraper.cs
@@ -25,7 +25,7 @@ namespace FrannHammer.WebScraping.Moves
             };
         }
 
-        protected override HtmlNodeCollection GetTableRows(string sourceUrl, string xpath)
+        protected override IEnumerable<HtmlNode> GetTableRows(string sourceUrl, string xpath)
         {
             const string exceptionMessageBase = "Error getting move table data after attempting to scrape full table using xpath: ";
             var htmlParser = ScrapingServices.CreateParserFromSourceUrl(sourceUrl);
@@ -39,6 +39,7 @@ namespace FrannHammer.WebScraping.Moves
 
                 //get row data
                 var tableRows = movesTableHtmlNode.SelectNodes(ScrapingConstants.XPathTableRows);
+                        
 
                 if (tableRows == null)
                 {
@@ -46,7 +47,18 @@ namespace FrannHammer.WebScraping.Moves
                         $"{exceptionMessageBase}'{ScrapingConstants.XPathTableRows};");
                 }
 
-                return tableRows;
+                return tableRows.Where(node =>
+                {
+                    var firstHeaderNode = node.SelectSingleNode("th");
+
+                    return
+                        !firstHeaderNode.InnerText.Equals(ScrapingConstants.ExcludedRowHeaders.Grabs,
+                            StringComparison.OrdinalIgnoreCase) &&
+                        !firstHeaderNode.InnerText.Equals(ScrapingConstants.ExcludedRowHeaders.Throws,
+                            StringComparison.OrdinalIgnoreCase) &&
+                        !firstHeaderNode.InnerText.Equals(ScrapingConstants.ExcludedRowHeaders.Miscellaneous,
+                            StringComparison.OrdinalIgnoreCase);
+                });
             }
             else
             {

--- a/src/Implementation/FrannHammer.WebScraping/ScrapingConstants.cs
+++ b/src/Implementation/FrannHammer.WebScraping/ScrapingConstants.cs
@@ -20,5 +20,12 @@
         public const string XPathTableNodeAttributesWithNoDescription = @"(//*/table[@id='AutoNumber1'])[1]";
         public const string XPathTableNodeAttributeHeaders = @"//*[@id='AutoNumber1'][2]/thead/tr";
         public const string XPathTableNodeAttributeHeadersWithNoDescription = @"//*[@id='AutoNumber1'][1]/thead/tr";
+
+        public class ExcludedRowHeaders
+        {
+            public const string Grabs = "Grabs";
+            public const string Throws = "Throws";
+            public const string Miscellaneous = "Miscellaneous";
+        }
     }
 }

--- a/src/Tests/FrannHammer.WebScraping.Tests/DefaultCharacterDataScrapingServiceIntegrationTests.cs
+++ b/src/Tests/FrannHammer.WebScraping.Tests/DefaultCharacterDataScrapingServiceIntegrationTests.cs
@@ -88,7 +88,7 @@ namespace FrannHammer.WebScraping.Tests
 
         private static IEnumerable<WebCharacter> Characters()
         {
-            return Domain.Characters.All;
+            return new List<WebCharacter> {Domain.Characters.Cloud, Domain.Characters.Greninja};
         }
 
         [Test]

--- a/src/Tests/FrannHammer.WebScraping.Tests/DefaultMoveScrapingServiceIntegrationTests.cs
+++ b/src/Tests/FrannHammer.WebScraping.Tests/DefaultMoveScrapingServiceIntegrationTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using FrannHammer.Domain.Contracts;
 using FrannHammer.WebScraping.Contracts.Moves;
 using FrannHammer.WebScraping.Domain;
@@ -39,6 +40,32 @@ namespace FrannHammer.WebScraping.Tests
             Assert.That(move.HitboxActive, Is.Not.Null);
             Assert.That(move.KnockbackGrowth, Is.Not.Null);
             Assert.That(move.Owner, Is.EqualTo(character.Name), $"{nameof(move.Owner)}");
+        }
+
+        [Test]
+        public void ScrapeGroundMoves_HeaderRowsAreExcludeFromScrapedValues()
+        {
+            var groundMoveScrapingService = new GroundMoveScraper(_scrapingServices);
+
+            var groundMoves = groundMoveScrapingService.Scrape(Characters.Greninja).ToList();
+
+            CollectionAssert.AllItemsAreNotNull(groundMoves);
+            CollectionAssert.AllItemsAreUnique(groundMoves);
+            CollectionAssert.IsNotEmpty(groundMoves);
+
+            groundMoves.ForEach(move =>
+            {
+                AssertMoveIsValid(move, Characters.Greninja);
+            });
+
+            Assert.That(!groundMoves.Any(move => move.Name.Equals(ScrapingConstants.ExcludedRowHeaders.Grabs, StringComparison.OrdinalIgnoreCase)),
+                $"Should not contain '{ScrapingConstants.ExcludedRowHeaders.Grabs}'");
+
+            Assert.That(!groundMoves.Any(move => move.Name.Equals(ScrapingConstants.ExcludedRowHeaders.Throws, StringComparison.OrdinalIgnoreCase)),
+                $"Should not contain '{ScrapingConstants.ExcludedRowHeaders.Throws}'");
+
+            Assert.That(!groundMoves.Any(move => move.Name.Equals(ScrapingConstants.ExcludedRowHeaders.Miscellaneous, StringComparison.OrdinalIgnoreCase)),
+                $"Should not contain '{ScrapingConstants.ExcludedRowHeaders.Miscellaneous}'");
         }
 
         [Test]


### PR DESCRIPTION
- BaseMoveScraper.GetTableRows now returns an IEnumerable<HtmlNode> instead of a HtmlNodeCollection.  Filtering is now performed in the scraped rows that excluded headers that don't contain data (but rather are just empty naming headers).