### PR TITLE
Fixes for 238, 239

### DIFF
--- a/src/Implementation/FrannHammer.WebScraping.Domain/Characters.cs
+++ b/src/Implementation/FrannHammer.WebScraping.Domain/Characters.cs
@@ -7,6 +7,7 @@ namespace FrannHammer.WebScraping.Domain
     {
         public static WebCharacter Greninja => new Greninja();
         public static WebCharacter Cloud => new Cloud();
+        public static WebCharacter Yoshi => new Yoshi();
 
         public static IEnumerable<WebCharacter> All => new List<WebCharacter>
         {

--- a/src/Implementation/FrannHammer.WebScraping/Moves/GroundMoveScraper.cs
+++ b/src/Implementation/FrannHammer.WebScraping/Moves/GroundMoveScraper.cs
@@ -47,18 +47,7 @@ namespace FrannHammer.WebScraping.Moves
                         $"{exceptionMessageBase}'{ScrapingConstants.XPathTableRows};");
                 }
 
-                return tableRows.Where(node =>
-                {
-                    var firstHeaderNode = node.SelectSingleNode("th");
-
-                    return
-                        !firstHeaderNode.InnerText.Equals(ScrapingConstants.ExcludedRowHeaders.Grabs,
-                            StringComparison.OrdinalIgnoreCase) &&
-                        !firstHeaderNode.InnerText.Equals(ScrapingConstants.ExcludedRowHeaders.Throws,
-                            StringComparison.OrdinalIgnoreCase) &&
-                        !firstHeaderNode.InnerText.Equals(ScrapingConstants.ExcludedRowHeaders.Miscellaneous,
-                            StringComparison.OrdinalIgnoreCase);
-                });
+                return FilterHeadersFromFoundTableRows(tableRows);
             }
             else
             {
@@ -74,8 +63,24 @@ namespace FrannHammer.WebScraping.Moves
                         $"{exceptionMessageBase}'{ScrapingConstants.XPathTableRows};");
                 }
 
-                return tableRows;
+                return FilterHeadersFromFoundTableRows(tableRows);
             }
+        }
+
+        private static IEnumerable<HtmlNode> FilterHeadersFromFoundTableRows(IEnumerable<HtmlNode> tableRows)
+        {
+            return tableRows.Where(node =>
+            {
+                var firstHeaderNode = node.SelectSingleNode("th");
+
+                return
+                    !firstHeaderNode.InnerText.Equals(ScrapingConstants.ExcludedRowHeaders.Grabs,
+                        StringComparison.OrdinalIgnoreCase) &&
+                    !firstHeaderNode.InnerText.Equals(ScrapingConstants.ExcludedRowHeaders.Throws,
+                        StringComparison.OrdinalIgnoreCase) &&
+                    !firstHeaderNode.InnerText.Equals(ScrapingConstants.ExcludedRowHeaders.Miscellaneous,
+                        StringComparison.OrdinalIgnoreCase);
+            });
         }
 
         protected override IMove GetMove(HtmlNodeCollection cells, WebCharacter character)
@@ -85,8 +90,7 @@ namespace FrannHammer.WebScraping.Moves
             string name = GetStatName(cells[0]);
 
             //a throw move is not a ground move
-            if (name.EndsWith("grab", StringComparison.CurrentCultureIgnoreCase) ||
-                name.EndsWith("throw", StringComparison.CurrentCultureIgnoreCase))
+            if (name.EndsWith(ScrapingConstants.CommonMoveNames.Throw, StringComparison.OrdinalIgnoreCase))
             {
                 return default(IMove);
             }

--- a/src/Implementation/FrannHammer.WebScraping/Moves/ThrowMoveScraper.cs
+++ b/src/Implementation/FrannHammer.WebScraping/Moves/ThrowMoveScraper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using FrannHammer.Domain.Contracts;
 using FrannHammer.WebScraping.Contracts.Moves;
@@ -8,10 +7,8 @@ using HtmlAgilityPack;
 
 namespace FrannHammer.WebScraping.Moves
 {
-    public class ThrowMoveScraper : BaseMoveScraper
+    public class ThrowMoveScraper : GroundMoveScraper
     {
-        public sealed override Func<WebCharacter, IEnumerable<IMove>> Scrape { get; protected set; }
-
         public ThrowMoveScraper(IMoveScrapingServices scrapingServices)
             : base(scrapingServices)
         {
@@ -38,18 +35,7 @@ namespace FrannHammer.WebScraping.Moves
                 move.OwnerId = character.OwnerId;
                 move.MoveType = MoveType.Throw.GetEnumDescription();
 
-                //grab data is different than 'throw' data.  If the cell contains neither of these this scraper
-                //will ignore it
-                if (name.EndsWith("grab", StringComparison.CurrentCultureIgnoreCase))
-                {
-                    string hitboxActive = cells[1].InnerText;
-                    string faf = cells[2].InnerText;
-
-                    move.HitboxActive = hitboxActive;
-                    move.FirstActionableFrame = faf;
-                    return move;
-                }
-                else if (name.EndsWith("throw", StringComparison.CurrentCultureIgnoreCase))
+                if (name.EndsWith("throw", StringComparison.CurrentCultureIgnoreCase))
                 {
                     bool isWeightDependent = TranslateYesNoToBool(cells[1].InnerText);
 

--- a/src/Implementation/FrannHammer.WebScraping/ScrapingConstants.cs
+++ b/src/Implementation/FrannHammer.WebScraping/ScrapingConstants.cs
@@ -27,5 +27,11 @@
             public const string Throws = "Throws";
             public const string Miscellaneous = "Miscellaneous";
         }
+
+        public class CommonMoveNames
+        {
+            public const string Grab = "Grab";
+            public const string Throw = "Throw";
+        }
     }
 }


### PR DESCRIPTION
- fixes [238](https://github.com/Frannsoft/FrannHammer/issues/238)

- Moves that are grabs (NOT throws) are now scraped as Ground type data in the GroundMoveScraper

- fixes [239](https://github.com/Frannsoft/FrannHammer/issues/239)

- Header cells on moves are no longer scraped on characters with unique properties (cloud, yoshi, etc)
- Throws are now added on these characters in the ThrowMoveScraper
- ThrowMoveScraper now derives from GroundMoveScraper instead of just BaseMoveScraper.  Both Ground and Throws have the same scraping logic as far as the overridden methods from BaseMoveScraper are concerned.

- Added tests to help ensure the above is actually true.