### PR TITLE
- Fixes 240

### DIFF
--- a/src/Contracts/FrannHammer.Api.Services.Contracts/FrannHammer.Api.Services.Contracts.csproj
+++ b/src/Contracts/FrannHammer.Api.Services.Contracts/FrannHammer.Api.Services.Contracts.csproj
@@ -44,6 +44,7 @@
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
     <Compile Include="ContentResponseBuilder.cs" />
+    <Compile Include="ICharacterAttributeNameProvider.cs" />
     <Compile Include="ICharacterAttributeRowService.cs" />
     <Compile Include="ICharacterService.cs" />
     <Compile Include="ICrudService.cs" />

--- a/src/Contracts/FrannHammer.Api.Services.Contracts/ICharacterAttributeNameProvider.cs
+++ b/src/Contracts/FrannHammer.Api.Services.Contracts/ICharacterAttributeNameProvider.cs
@@ -1,0 +1,9 @@
+﻿using FrannHammer.Domain.Contracts;
+
+namespace FrannHammer.Api.Services.Contracts
+{
+    public interface ICharacterAttributeNameProvider
+    {
+        ICharacterAttributeName Create(string name);
+    }
+}

--- a/src/Contracts/FrannHammer.Api.Services.Contracts/ICharacterAttributeRowService.cs
+++ b/src/Contracts/FrannHammer.Api.Services.Contracts/ICharacterAttributeRowService.cs
@@ -7,5 +7,6 @@ namespace FrannHammer.Api.Services.Contracts
     {
         IEnumerable<ICharacterAttributeRow> GetAllWhereCharacterNameIs(string name);
         IEnumerable<ICharacterAttributeRow> GetAllWhereCharacterOwnerIdIs(int id);
+        IEnumerable<ICharacterAttributeName> GetAllTypes();
     }
 }

--- a/src/Contracts/FrannHammer.Domain.Contracts/FrannHammer.Domain.Contracts.csproj
+++ b/src/Contracts/FrannHammer.Domain.Contracts/FrannHammer.Domain.Contracts.csproj
@@ -48,6 +48,7 @@
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
     <Compile Include="IAttribute.cs" />
+    <Compile Include="ICharacterAttributeName.cs" />
     <Compile Include="ICharacterAttributeRow.cs" />
     <Compile Include="ICharacter.cs" />
     <Compile Include="ICharacterDetailsDto.cs" />

--- a/src/Contracts/FrannHammer.Domain.Contracts/ICharacterAttributeName.cs
+++ b/src/Contracts/FrannHammer.Domain.Contracts/ICharacterAttributeName.cs
@@ -1,0 +1,6 @@
+﻿namespace FrannHammer.Domain.Contracts
+{
+    public interface ICharacterAttributeName : IModel
+    {
+    }
+}

--- a/src/Implementation/FrannHammer.Api.Services/DefaultCharacterAttributeNameProvider.cs
+++ b/src/Implementation/FrannHammer.Api.Services/DefaultCharacterAttributeNameProvider.cs
@@ -1,0 +1,17 @@
+﻿using FrannHammer.Api.Services.Contracts;
+using FrannHammer.Domain;
+using FrannHammer.Domain.Contracts;
+
+namespace FrannHammer.Api.Services
+{
+    public class DefaultCharacterAttributeNameProvider : ICharacterAttributeNameProvider
+    {
+        public ICharacterAttributeName Create(string name)
+        {
+            return new CharacterAttributeName
+            {
+                Name = name
+            };
+        }
+    }
+}

--- a/src/Implementation/FrannHammer.Api.Services/DefaultCharacterAttributeService.cs
+++ b/src/Implementation/FrannHammer.Api.Services/DefaultCharacterAttributeService.cs
@@ -4,19 +4,31 @@ using FrannHammer.Api.Services.Contracts;
 using FrannHammer.DataAccess.Contracts;
 using FrannHammer.Domain.Contracts;
 using FrannHammer.Utility;
+using System.Linq;
 
 namespace FrannHammer.Api.Services
 {
     public class DefaultCharacterAttributeService : OwnerBasedApiService<ICharacterAttributeRow>, ICharacterAttributeRowService
     {
-        public DefaultCharacterAttributeService(IRepository<ICharacterAttributeRow> characterAttributeRowRepository)
+        private readonly ICharacterAttributeNameProvider _characterAttributeNameProvider;
+
+        public DefaultCharacterAttributeService(IRepository<ICharacterAttributeRow> characterAttributeRowRepository,
+            ICharacterAttributeNameProvider characterAttributeNameProvider)
             : base(characterAttributeRowRepository)
-        { }
+        {
+            Guard.VerifyObjectNotNull(characterAttributeNameProvider, nameof(characterAttributeNameProvider));
+            _characterAttributeNameProvider = characterAttributeNameProvider;
+        }
 
         public override IEnumerable<ICharacterAttributeRow> GetAllWhereCharacterNameIs(string name)
         {
             Guard.VerifyStringIsNotNullOrEmpty(name, nameof(name));
             return GetAllWhere(item => item.Owner.Equals(name, StringComparison.OrdinalIgnoreCase));
         }
+
+        public IEnumerable<ICharacterAttributeName> GetAllTypes()
+        {
+            return GetAll().Select(attr => _characterAttributeNameProvider.Create(attr.Name));
+        } 
     }
 }

--- a/src/Implementation/FrannHammer.Api.Services/FrannHammer.Api.Services.csproj
+++ b/src/Implementation/FrannHammer.Api.Services/FrannHammer.Api.Services.csproj
@@ -45,6 +45,7 @@
     </Compile>
     <Compile Include="DefaultAttributeStrategy.cs" />
     <Compile Include="BaseApiService.cs" />
+    <Compile Include="DefaultCharacterAttributeNameProvider.cs" />
     <Compile Include="DefaultCharacterAttributeService.cs" />
     <Compile Include="DefaultCharacterService.cs" />
     <Compile Include="DefaultDtoProvider.cs" />

--- a/src/Implementation/FrannHammer.DefaultContainer.Configuration/ContainerModules/ApiServicesModule.cs
+++ b/src/Implementation/FrannHammer.DefaultContainer.Configuration/ContainerModules/ApiServicesModule.cs
@@ -43,10 +43,14 @@ namespace FrannHammer.DefaultContainer.Configuration.ContainerModules
                 .WithParameter((pi, c) => pi.Name == QueryMappingParameterName,
                  (pi, c) => c.Resolve<IQueryMappingService>());
 
+            builder.RegisterType<DefaultCharacterAttributeNameProvider>().As<ICharacterAttributeNameProvider>();
+
             builder.RegisterType<DefaultCharacterAttributeService>()
                 .As<ICharacterAttributeRowService>()
                 .WithParameter((pi, c) => pi.Name == RepositoryParameterName,
-                    (pi, c) => c.Resolve<IRepository<ICharacterAttributeRow>>());
+                    (pi, c) => c.Resolve<IRepository<ICharacterAttributeRow>>())
+                    .WithParameter((pi, c) => pi.Name == "characterAttributeNameProvider",
+                    (pi, c) => c.Resolve<ICharacterAttributeNameProvider>());
 
             builder.RegisterType<DefaultAttributeStrategy>().As<IAttributeStrategy>();
 

--- a/src/Implementation/FrannHammer.DefaultContainer.Configuration/ContainerModules/ModelModule.cs
+++ b/src/Implementation/FrannHammer.DefaultContainer.Configuration/ContainerModules/ModelModule.cs
@@ -9,6 +9,7 @@ namespace FrannHammer.DefaultContainer.Configuration.ContainerModules
         protected override void Load(ContainerBuilder builder)
         {
             builder.RegisterType<CharacterAttribute>().As<IAttribute>();
+            builder.RegisterType<CharacterAttributeName>().As<ICharacterAttributeName>();
             builder.RegisterType<CharacterAttributeRow>().As<ICharacterAttributeRow>();
             builder.RegisterType<Character>().As<ICharacter>();
             builder.RegisterType<Move>().As<IMove>();

--- a/src/Implementation/FrannHammer.Domain/CharacterAttributeName.cs
+++ b/src/Implementation/FrannHammer.Domain/CharacterAttributeName.cs
@@ -1,0 +1,8 @@
+﻿using FrannHammer.Domain.Contracts;
+
+namespace FrannHammer.Domain
+{
+    public class CharacterAttributeName : MongoModel, ICharacterAttributeName
+    {
+    }
+}

--- a/src/Implementation/FrannHammer.Domain/FrannHammer.Domain.csproj
+++ b/src/Implementation/FrannHammer.Domain/FrannHammer.Domain.csproj
@@ -49,6 +49,7 @@
     <Compile Include="BsonMapper.cs" />
     <Compile Include="Character.cs" />
     <Compile Include="CharacterAttribute.cs" />
+    <Compile Include="CharacterAttributeName.cs" />
     <Compile Include="CharacterAttributeRow.cs" />
     <Compile Include="CharacterDetailsDto.cs" />
     <Compile Include="FriendlyNameAttribute.cs" />

--- a/src/Implementation/FrannHammer.WebApi/Controllers/CharacterAttributeController.cs
+++ b/src/Implementation/FrannHammer.WebApi/Controllers/CharacterAttributeController.cs
@@ -31,10 +31,18 @@ namespace FrannHammer.WebApi.Controllers
             return Result(content);
         }
 
-        [Route(CharacterAttributesRouteKey + "/name/{name}", Name = nameof(GetSingleCharacterAttributeByName))]
-        public IHttpActionResult GetSingleCharacterAttributeByName(string name)
+        [Route(CharacterAttributesRouteKey + "/name/{name}", Name = nameof(GetAllCharacterAttributesWithName))]
+        public IHttpActionResult GetAllCharacterAttributesWithName(string name)
         {
             var content = _characterAttributeRowService.GetAllWhereName(name);
+            return Result(content);
+        }
+
+        [Route(CharacterAttributesRouteKey + "/types", Name = nameof(GetAllCharacterAttributeTypes))]
+
+        public IHttpActionResult GetAllCharacterAttributeTypes()
+        {
+            var content = _characterAttributeRowService.GetAllTypes();
             return Result(content);
         }
     }

--- a/src/Implementation/FrannHammer.WebApi/FrannHammer.WebApi.csproj
+++ b/src/Implementation/FrannHammer.WebApi/FrannHammer.WebApi.csproj
@@ -244,8 +244,10 @@
     <Compile Include="Controllers\MovementController.cs" />
     <Compile Include="Controllers\UniqueDataController.cs" />
     <Compile Include="EnrichingHandler.cs" />
+    <Compile Include="HypermediaServices\CharacterAttributeNameResourceEnricher.cs" />
     <Compile Include="HypermediaServices\CharacterAttributeRowResourceEnricher.cs" />
     <Compile Include="HypermediaServices\CharacterResourceEnricher.cs" />
+    <Compile Include="HypermediaServices\ManyCharacterAttributeNameResourceEnricher.cs" />
     <Compile Include="HypermediaServices\ManyCharacterAttributeRowResourceEnricher.cs" />
     <Compile Include="HypermediaServices\ManyCharacterResourceEnricher.cs" />
     <Compile Include="HypermediaServices\ManyMovementResourceEnricher.cs" />
@@ -255,6 +257,7 @@
     <Compile Include="HypermediaServices\MoveResourceEnricher.cs" />
     <Compile Include="HypermediaServices\ObjectContentResponseEnricher.cs" />
     <Compile Include="HypermediaServices\UniqueDataResourceEnricher.cs" />
+    <Compile Include="Models\CharacterAttributeNameResource.cs" />
     <Compile Include="Models\CharacterAttributeRowResource.cs" />
     <Compile Include="Models\MovementResource.cs" />
     <Compile Include="CustomExceptionFilterAttribute.cs" />

--- a/src/Implementation/FrannHammer.WebApi/HypermediaServices/CharacterAttributeNameResourceEnricher.cs
+++ b/src/Implementation/FrannHammer.WebApi/HypermediaServices/CharacterAttributeNameResourceEnricher.cs
@@ -1,0 +1,28 @@
+﻿using System.Web.Http.Routing;
+using AutoMapper;
+using FrannHammer.Domain.Contracts;
+using FrannHammer.WebApi.Controllers;
+using FrannHammer.WebApi.Models;
+
+namespace FrannHammer.WebApi.HypermediaServices
+{
+    public class CharacterAttributeNameResourceEnricher :
+        ObjectContentResponseEnricher<ICharacterAttributeName, CharacterAttributeNameResource>
+    {
+        public CharacterAttributeNameResourceEnricher(ILinkProvider linkProvider, IMapper entityToDtoMapper)
+            : base(linkProvider, entityToDtoMapper)
+        {
+        }
+
+        public override CharacterAttributeNameResource Enrich(ICharacterAttributeName content, UrlHelper urlHelper)
+        {
+            var resource = EntityToDtoMapper.Map<CharacterAttributeNameResource>(content);
+
+            var allAttributesForNameLink = CreateNameBasedLink<CharacterAttributesLink>(content.Name, urlHelper, nameof(CharacterAttributeController.GetAllCharacterAttributesWithName));
+
+            resource.AddLink(allAttributesForNameLink);
+
+            return resource;
+        }
+    }
+}

--- a/src/Implementation/FrannHammer.WebApi/HypermediaServices/ManyCharacterAttributeNameResourceEnricher.cs
+++ b/src/Implementation/FrannHammer.WebApi/HypermediaServices/ManyCharacterAttributeNameResourceEnricher.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http.Routing;
+using FrannHammer.Domain.Contracts;
+using FrannHammer.Utility;
+using FrannHammer.WebApi.Models;
+
+namespace FrannHammer.WebApi.HypermediaServices
+{
+    public class ManyCharacterAttributeNameResourceEnricher :
+        ObjectContentResponseEnricher<IEnumerable<ICharacterAttributeName>, IEnumerable<CharacterAttributeNameResource>>
+    {
+        private readonly CharacterAttributeNameResourceEnricher _singleResourceEnricher;
+
+        public ManyCharacterAttributeNameResourceEnricher(CharacterAttributeNameResourceEnricher singleResourceEnricher) 
+            : base(singleResourceEnricher.LinkProvider, singleResourceEnricher.EntityToDtoMapper)
+        {
+            Guard.VerifyObjectNotNull(singleResourceEnricher, nameof(singleResourceEnricher));
+            _singleResourceEnricher = singleResourceEnricher;
+        }
+
+        public override IEnumerable<CharacterAttributeNameResource> Enrich(IEnumerable<ICharacterAttributeName> content, UrlHelper urlHelper)
+        {
+            return content.Select(characterAttributeRowName => _singleResourceEnricher.Enrich(characterAttributeRowName, urlHelper));
+        }
+    }
+}

--- a/src/Implementation/FrannHammer.WebApi/HypermediaServices/ManyCharacterAttributeRowResourceEnricher.cs
+++ b/src/Implementation/FrannHammer.WebApi/HypermediaServices/ManyCharacterAttributeRowResourceEnricher.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Web.Http.Routing;
+using AutoMapper;
 using FrannHammer.Domain.Contracts;
 using FrannHammer.Utility;
 using FrannHammer.WebApi.Models;

--- a/src/Implementation/FrannHammer.WebApi/Models/CharacterAttributeNameResource.cs
+++ b/src/Implementation/FrannHammer.WebApi/Models/CharacterAttributeNameResource.cs
@@ -1,0 +1,7 @@
+﻿namespace FrannHammer.WebApi.Models
+{
+    public class CharacterAttributeNameResource : Resource
+    {
+        public string Name { get; set; }
+    }
+}

--- a/src/Implementation/FrannHammer.WebApi/ResourceEnrichmentModule.cs
+++ b/src/Implementation/FrannHammer.WebApi/ResourceEnrichmentModule.cs
@@ -16,6 +16,8 @@ namespace FrannHammer.WebApi
             builder.RegisterType<ManyMovementResourceEnricher>().AsSelf();
             builder.RegisterType<CharacterAttributeRowResourceEnricher>().AsSelf();
             builder.RegisterType<ManyCharacterAttributeRowResourceEnricher>().AsSelf();
+            builder.RegisterType<CharacterAttributeNameResourceEnricher>().AsSelf();
+            builder.RegisterType<ManyCharacterAttributeNameResourceEnricher>().AsSelf();
             builder.RegisterType<UniqueDataResourceEnricher>().AsSelf();
             builder.RegisterType<ManyUniqueDataResourceEnricher>().AsSelf();
             builder.RegisterType<LinkProvider>().As<ILinkProvider>();

--- a/src/Implementation/FrannHammer.WebApi/Startup.cs
+++ b/src/Implementation/FrannHammer.WebApi/Startup.cs
@@ -7,7 +7,6 @@ using FrannHammer.DefaultContainer.Configuration.ContainerModules;
 using FrannHammer.Domain;
 using FrannHammer.WebApi;
 using Microsoft.Owin;
-using Microsoft.Owin.Cors;
 using Owin;
 using System.Linq;
 using System.Net.Http.Formatting;
@@ -64,8 +63,6 @@ namespace FrannHammer.WebApi
             app.UseAutofacMiddleware(Container);
             app.UseAutofacWebApi(config);
             app.UseWebApi(config);
-            //app.UseCors(CorsOptions.AllowAll);
-            //config.EnableCors();
         }
 
         private static void BuildContainer(HttpConfiguration config)
@@ -97,6 +94,7 @@ namespace FrannHammer.WebApi
                 cfg.CreateMap<IMove, MoveResource>();
                 cfg.CreateMap<IMovement, MovementResource>();
                 cfg.CreateMap<ICharacterAttributeRow, CharacterAttributeRowResource>();
+                cfg.CreateMap<ICharacterAttributeName, CharacterAttributeNameResource>();
                 cfg.CreateMap<IUniqueData, UniqueDataResource>();
             });
         }
@@ -135,7 +133,9 @@ namespace FrannHammer.WebApi
                 Container.Resolve<CharacterAttributeRowResourceEnricher>(),
                 Container.Resolve<ManyCharacterAttributeRowResourceEnricher>(),
                 Container.Resolve<UniqueDataResourceEnricher>(),
-                Container.Resolve<ManyUniqueDataResourceEnricher>());
+                Container.Resolve<ManyUniqueDataResourceEnricher>(),
+                Container.Resolve<CharacterAttributeNameResourceEnricher>(),
+                Container.Resolve<ManyCharacterAttributeNameResourceEnricher>());
         }
 
         private static void ConfigureSwagger(HttpConfiguration config)

--- a/src/Tests/FrannHammer.Seeding.Tests/DefaultSeederIntegrationTests.cs
+++ b/src/Tests/FrannHammer.Seeding.Tests/DefaultSeederIntegrationTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using FrannHammer.Api.Services;
+using FrannHammer.Api.Services.Contracts;
 using FrannHammer.DataAccess.MongoDb;
 using FrannHammer.Domain;
 using FrannHammer.Domain.Contracts;
@@ -128,7 +129,7 @@ namespace FrannHammer.Seeding.Tests
             var dtoProvider = new DefaultDtoProvider();
             var movementService = new DefaultMovementService(movementRepository, mockQueryMappingService);
             var moveService = new DefaultMoveService(moveRepository, mockQueryMappingService);
-            var characterAttributeService = new DefaultCharacterAttributeService(characterAttributeRepository);
+            var characterAttributeService = new DefaultCharacterAttributeService(characterAttributeRepository, new Mock<ICharacterAttributeNameProvider>().Object);
             var uniqueDataService = new DefaultUniqueDataService(uniqueDataRepository, mockQueryMappingService);
             var characterService = new DefaultCharacterService(characterRepository, dtoProvider,
                 movementService, characterAttributeService, moveService, uniqueDataService);

--- a/src/Tests/FrannHammer.Seeding.Tests/DefaultSeederTests.cs
+++ b/src/Tests/FrannHammer.Seeding.Tests/DefaultSeederTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using FrannHammer.Api.Services;
+using FrannHammer.Api.Services.Contracts;
 using FrannHammer.DataAccess.Contracts;
 using FrannHammer.Domain.Contracts;
 using FrannHammer.WebScraping;
@@ -149,7 +150,7 @@ namespace FrannHammer.Seeding.Tests
             //real api services using mocked repos
             var movementService = new DefaultMovementService(movementRepositoryMock.Object, new Mock<IQueryMappingService>().Object);
             var moveService = new DefaultMoveService(movesRepositoryMock.Object, new Mock<IQueryMappingService>().Object);
-            var characterAttributeService = new DefaultCharacterAttributeService(characterAttributeRepositoryMock.Object);
+            var characterAttributeService = new DefaultCharacterAttributeService(characterAttributeRepositoryMock.Object, new Mock<ICharacterAttributeNameProvider>().Object);
             var uniqueDataService = new DefaultUniqueDataService(uniqueDataRepositoryMock.Object, new Mock<IQueryMappingService>().Object);
             var dtoProvider = new DefaultDtoProvider();
             var characterService = new DefaultCharacterService(characterRepositoryMock.Object, dtoProvider,

--- a/src/Tests/FrannHammer.WebApi.Specs/Attributes/CharacterAttributesApi.feature
+++ b/src/Tests/FrannHammer.WebApi.Specs/Attributes/CharacterAttributesApi.feature
@@ -8,8 +8,7 @@ Scenario: Request All Character Attribute Rows
 	When I request all data
 	Then The result should be a list of all character attribute row entries
 
-#@Get
-#Scenario: Request one single Character Attribute Row
-#	Given The api route of api/characterattributes/{id}
-#	When I request one specific item by id 5913c30e4696591c50f28673
-#	Then The result should be just that character attribute row
+Scenario: I want to get back the names of all available character attributes
+	Given The api route of api/characterattributes/types
+	When I request all data
+	Then The result should be a list of all character attribute types

--- a/src/Tests/FrannHammer.WebApi.Specs/Attributes/CharacterAttributesApi.feature.cs
+++ b/src/Tests/FrannHammer.WebApi.Specs/Attributes/CharacterAttributesApi.feature.cs
@@ -82,6 +82,23 @@ this.ScenarioSetup(scenarioInfo);
 #line hidden
             this.ScenarioCleanup();
         }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("I want to get back the names of all available character attributes")]
+        public virtual void IWantToGetBackTheNamesOfAllAvailableCharacterAttributes()
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("I want to get back the names of all available character attributes", ((string[])(null)));
+#line 11
+this.ScenarioSetup(scenarioInfo);
+#line 12
+ testRunner.Given("The api route of api/characterattributes/types", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 13
+ testRunner.When("I request all data", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 14
+ testRunner.Then("The result should be a list of all character attribute types", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+            this.ScenarioCleanup();
+        }
     }
 }
 #pragma warning restore

--- a/src/Tests/FrannHammer.WebApi.Specs/Attributes/CharacterAttributesApiSteps.cs
+++ b/src/Tests/FrannHammer.WebApi.Specs/Attributes/CharacterAttributesApiSteps.cs
@@ -45,5 +45,15 @@ namespace FrannHammer.WebApi.Specs.Attributes
 
             AssertCharacterAttributeRowIsValid(characterMetadata);
         }
+
+        [Then(@"The result should be a list of all character attribute types")]
+        public void ThenTheResultShouldBeAListOfAllCharacterAttributeTypes()
+        {
+            var typesCollection = ApiClient
+                .DeserializeResponse<IEnumerable<CharacterAttributeNameResource>>(
+                    ScenarioContext.Current.Get<HttpResponseMessage>(RequestResultKey)).ToList();
+
+            typesCollection.ForEach(AssertCharacterAttributeIsValid);
+        }
     }
 }

--- a/src/Tests/FrannHammer.WebApi.Specs/ResourceAsserts.cs
+++ b/src/Tests/FrannHammer.WebApi.Specs/ResourceAsserts.cs
@@ -29,6 +29,17 @@ namespace FrannHammer.WebApi.Specs
             });
         }
 
+        public static void AssertCharacterAttributeIsValid(CharacterAttributeNameResource characterAttributeName)
+        {
+            Assert.That(characterAttributeName.Name, Is.Not.Null, $"{nameof(characterAttributeName.Name)}");
+
+            var allAttributesByNameLink = characterAttributeName.Links.FirstOrDefault(l => l.Rel.Equals(CharacterAttributeLinkName));
+            Assert.That(allAttributesByNameLink, Is.Not.Null, $"Unable to find '{CharacterAttributeLinkName}' link.");
+
+            // ReSharper disable once PossibleNullReferenceException
+            Assert.That(allAttributesByNameLink.Href, Contains.Substring(characterAttributeName.Name));
+        }
+
         public static void AssertCharacterIsValid(CharacterResource characterResource)
         {
             Assert.That(characterResource, Is.Not.Null, $"{nameof(characterResource)}");


### PR DESCRIPTION
- This was a bit more involved than I thought it would be (ugh)
- Added a new DTO to house character attribute name responses
- Added resource enrichers so I could include a link to getting back all of the actual character attribute values for each type in the returned collection via the new call /characterattributes/types

- Adjusted DefaultCharacterAttributeService ctor to require an instance of ICharacterAttributeNameProvider (ugh) to support the new api service call that return these attribute name objects.  The api service call just gets back all character attributes, then selects a collection consisting of just the names to create the name resource and send it back.